### PR TITLE
Fixes project to conform to StyleCop rules

### DIFF
--- a/src/Our.Umbraco.Ditto/Attributes/DittoIgnoreAttribute.cs
+++ b/src/Our.Umbraco.Ditto/Attributes/DittoIgnoreAttribute.cs
@@ -1,7 +1,21 @@
-﻿using System;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DittoIgnoreAttribute.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   The Ditto ignore property attribute. Used for specifying that Umbraco should
+//   ignore this property during conversion.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.Attributes
 {
+    using System;
+
+    /// <summary>
+    /// The Ditto ignore property attribute. Used for specifying that Umbraco should
+    /// ignore this property during conversion.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class DittoIgnoreAttribute : Attribute
     {

--- a/src/Our.Umbraco.Ditto/Attributes/UmbracoPropertyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/Attributes/UmbracoPropertyAttribute.cs
@@ -1,24 +1,65 @@
-﻿using System;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UmbracoPropertyAttribute.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   The Umbraco property attribute.
+//   Used for providing Umbraco with additional information about the property to aid conversion.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.Attributes
 {
+    using System;
+
+    /// <summary>
+    /// The Umbraco property attribute. 
+    /// Used for providing Umbraco with additional information about the property to aid conversion.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class UmbracoPropertyAttribute : Attribute
     {
-        public string PropertyName { get; set; }
-
-        public string AltPropertyName { get; set; }
-
-        public bool Recursive { get; set; }
-
-        public object DefaultValue { get; set; }
-
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoPropertyAttribute"/> class.
+        /// </summary>
+        /// <param name="propertyName">
+        /// The property name.
+        /// </param>
+        /// <param name="altPropertyName">
+        /// The alternative property name.
+        /// </param>
+        /// <param name="recursive">
+        /// Whether the property should be retrieved recursively up the tree.
+        /// </param>
+        /// <param name="defaultValue">
+        /// The default value.
+        /// </param>
         public UmbracoPropertyAttribute(string propertyName, string altPropertyName = "", bool recursive = false, object defaultValue = null)
         {
-            PropertyName = propertyName;
-            AltPropertyName = altPropertyName;
-            Recursive = recursive;
-            DefaultValue = defaultValue;
+            this.PropertyName = propertyName;
+            this.AltPropertyName = altPropertyName;
+            this.Recursive = recursive;
+            this.DefaultValue = defaultValue;
         }
+
+        /// <summary>
+        /// Gets or sets the property name.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the alternative property name.
+        /// </summary>
+        public string AltPropertyName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the property should be retrieved recursively up the tree.
+        /// </summary>
+        public bool Recursive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default value.
+        /// </summary>
+        public object DefaultValue { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/EventArgs/ConvertedTypeEventArgs.cs
+++ b/src/Our.Umbraco.Ditto/EventArgs/ConvertedTypeEventArgs.cs
@@ -1,14 +1,36 @@
-﻿using System;
-using Umbraco.Core.Models;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ConvertedTypeEventArgs.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   Provides data for a converted event.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.EventArgs
 {
+    using System;
+
+    using global::Umbraco.Core.Models;
+
+    /// <summary>
+    /// Provides data for a converted event.
+    /// </summary>
     public class ConvertedTypeEventArgs : EventArgs
     {
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
         public IPublishedContent Content { get; set; }
 
+        /// <summary>
+        /// Gets or sets the converted object.
+        /// </summary>
         public object Converted { get; set; }
 
+        /// <summary>
+        /// Gets or sets the converted type.
+        /// </summary>
         public Type ConvertedType { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/EventArgs/ConvertingTypeEventArgs.cs
+++ b/src/Our.Umbraco.Ditto/EventArgs/ConvertingTypeEventArgs.cs
@@ -1,10 +1,26 @@
-﻿using System.ComponentModel;
-using Umbraco.Core.Models;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ConvertingTypeEventArgs.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   Provides data for a converting event.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.EventArgs
 {
+    using System.ComponentModel;
+
+    using global::Umbraco.Core.Models;
+
+    /// <summary>
+    /// Provides data for a converting event.
+    /// </summary>
     public class ConvertingTypeEventArgs : CancelEventArgs
     {
+        /// <summary>
+        /// Gets or sets the content.
+        /// </summary>
         public IPublishedContent Content { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/EventArgs/EventHandlers.cs
+++ b/src/Our.Umbraco.Ditto/EventArgs/EventHandlers.cs
@@ -1,23 +1,57 @@
-﻿using System;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EventHandlers.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   Provides methods to handle firing specific conversion events.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.EventArgs
 {
+    using System;
+
+    /// <summary>
+    /// Provides methods to handle firing specific conversion events.
+    /// </summary>
     public static class EventHandlers
     {
+        /// <summary>
+        /// The converting type method handler.
+        /// </summary>
         public static event EventHandler<ConvertingTypeEventArgs> ConvertingType;
 
+        /// <summary>
+        /// The converted type method handler.
+        /// </summary>
         public static event EventHandler<ConvertedTypeEventArgs> ConvertedType;
 
+        /// <summary>
+        /// Calls any methods designed to handle <see cref="ConvertingTypeEventArgs"/> events.
+        /// </summary>
+        /// <param name="args">
+        /// The <see cref="ConvertingTypeEventArgs"/>.
+        /// </param>
         public static void CallConvertingTypeHandler(ConvertingTypeEventArgs args)
         {
             if (ConvertingType != null)
+            {
                 ConvertingType(null, args);
+            }
         }
 
+        /// <summary>
+        /// Calls any methods designed to handle <see cref="ConvertedTypeEventArgs"/> events.
+        /// </summary>
+        /// <param name="args">
+        /// The <see cref="ConvertedTypeEventArgs"/>.
+        /// </param>
         public static void CallConvertedTypeHandler(ConvertedTypeEventArgs args)
         {
             if (ConvertedType != null)
+            {
                 ConvertedType(null, args);
+            }
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -1,33 +1,142 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
-using Umbraco.Core;
-using Umbraco.Core.Models;
-using Umbraco.Web;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PublishedContentExtensions.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   Encapsulates extension methods for <see cref="IPublishedContent" />.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.Extensions
 {
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+    using System.Reflection;
+
+    using Our.Umbraco.Ditto.Attributes;
+    using Our.Umbraco.Ditto.EventArgs;
+
+    using global::Umbraco.Core;
+    using global::Umbraco.Core.Models;
+    using global::Umbraco.Web;
+
+    /// <summary>
+    /// Encapsulates extension methods for <see cref="IPublishedContent"/>.
+    /// </summary>
     public static class PublishedContentExtensions
     {
-        internal static object As(this IPublishedContent content, Type type,
+        /// <summary>
+        /// Returns the given instance of <see cref="IPublishedContent"/> as the specified type.
+        /// </summary>
+        /// <param name="content">
+        /// The <see cref="IPublishedContent"/> to convert.
+        /// </param>
+        /// <param name="convertingType">
+        /// The <see cref="Action{ConvertingTypeEventArgs}"/> to fire when converting.
+        /// </param>
+        /// <param name="convertedType">
+        /// The <see cref="Action{ConvertedTypeEventArgs}"/> to fire when converted.
+        /// </param>
+        /// <typeparam name="T">
+        /// The <see cref="Type"/> of items to return.
+        /// </typeparam>
+        /// <returns>
+        /// The resolved <see cref="T"/>.
+        /// </returns>
+        public static T As<T>(
+            this IPublishedContent content,
+            Action<ConvertingTypeEventArgs> convertingType = null,
+            Action<ConvertedTypeEventArgs> convertedType = null)
+            where T : class
+        {
+            return content.As(typeof(T), convertingType, convertedType) as T;
+        }
+
+        /// <summary>
+        /// Gets a collection of the given type from the given <see cref="IEnumerable{IPublishedContent}"/>.
+        /// </summary>
+        /// <param name="items">
+        /// The <see cref="IEnumerable{IPublishedContent}"/> to convert.
+        /// </param>
+        /// <param name="documentTypeAlias">
+        /// The document type alias.
+        /// </param>
+        /// <param name="convertingType">
+        /// The <see cref="Action{ConvertingTypeEventArgs}"/> to fire when converting.
+        /// </param>
+        /// <param name="convertedType">
+        /// The <see cref="Action{ConvertedTypeEventArgs}"/> to fire when converted.
+        /// </param>
+        /// <typeparam name="T">
+        /// The <see cref="Type"/> of items to return.
+        /// </typeparam>
+        /// <returns>
+        /// The resolved <see cref="IEnumerable{T}"/>.
+        /// </returns>
+        public static IEnumerable<T> As<T>(
+            this IEnumerable<IPublishedContent> items,
+            string documentTypeAlias = null,
+            Action<ConvertingTypeEventArgs> convertingType = null,
+            Action<ConvertedTypeEventArgs> convertedType = null)
+            where T : class
+        {
+            using (DisposableTimer.DebugDuration<IEnumerable<T>>(string.Format("IEnumerable As ({0})", documentTypeAlias)))
+            {
+                if (string.IsNullOrWhiteSpace(documentTypeAlias))
+                {
+                    return items.Select(x => x.As<T>(convertingType, convertedType));
+                }
+
+                return items
+                    .Where(x => documentTypeAlias.InvariantEquals(x.DocumentTypeAlias))
+                    .Select(x => x.As<T>(convertingType, convertedType));
+            }
+        }
+
+        /// <summary>
+        /// Returns an object representing the given <see cref="Type"/>.
+        /// </summary>
+        /// <param name="content">
+        /// The <see cref="IPublishedContent"/> to convert.
+        /// </param>
+        /// <param name="type">
+        /// The <see cref="Type"/> of items to return.
+        /// </param>
+        /// <param name="convertingType">
+        /// The <see cref="Action{ConvertingTypeEventArgs}"/> to fire when converting.
+        /// </param>
+        /// <param name="convertedType">
+        /// The <see cref="Action{ConvertedTypeEventArgs}"/> to fire when converted.
+        /// </param>
+        /// <returns>
+        /// The converted <see cref="Object"/> as the given type.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the given type has invalid constructors.
+        /// </exception>
+        internal static object As(
+            this IPublishedContent content,
+            Type type,
             Action<ConvertingTypeEventArgs> convertingType = null,
             Action<ConvertedTypeEventArgs> convertedType = null)
         {
             object instance = null;
 
             if (content == null)
+            {
                 return instance;
+            }
 
             using (DisposableTimer.DebugDuration(type, string.Format("IPublishedContent As ({0})", content.DocumentTypeAlias), "Complete"))
             {
-                var constructor = type.GetConstructors()
+                ConstructorInfo constructor = type.GetConstructors()
                     .OrderBy(x => x.GetParameters().Length)
                     .First();
-                var constructorParams = constructor.GetParameters();
+                ParameterInfo[] constructorParams = constructor.GetParameters();
 
-                var args1 = new ConvertingTypeEventArgs { Content = content };
+                ConvertingTypeEventArgs args1 = new ConvertingTypeEventArgs { Content = content };
 
                 EventHandlers.CallConvertingTypeHandler(args1);
 
@@ -50,24 +159,26 @@ namespace Our.Umbraco.Ditto
                     throw new InvalidOperationException("Type {0} has invalid constructor parameters");
                 }
 
-                var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-                var contentType = content.GetType();
+                PropertyInfo[] properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+                Type contentType = content.GetType();
 
-                foreach (var propertyInfo in properties.Where(x => x.CanWrite))
+                foreach (PropertyInfo propertyInfo in properties.Where(x => x.CanWrite))
                 {
                     using (DisposableTimer.DebugDuration(type, string.Format("ForEach Property ({1} {0})", propertyInfo.Name, content.Id), "Complete"))
                     {
-                        // check for the ignore attribute
-                        var ignoreAttr = propertyInfo.GetCustomAttribute<DittoIgnoreAttribute>();
+                        // Check for the ignore attribute.
+                        DittoIgnoreAttribute ignoreAttr = propertyInfo.GetCustomAttribute<DittoIgnoreAttribute>();
                         if (ignoreAttr != null)
+                        {
                             continue;
+                        }
 
-                        var umbracoPropertyName = propertyInfo.Name;
-                        var altUmbracoPropertyName = string.Empty;
-                        var recursive = false;
+                        string umbracoPropertyName = propertyInfo.Name;
+                        string altUmbracoPropertyName = string.Empty;
+                        bool recursive = false;
                         object defaultValue = null;
 
-                        var umbracoPropertyAttr = propertyInfo.GetCustomAttribute<UmbracoPropertyAttribute>();
+                        UmbracoPropertyAttribute umbracoPropertyAttr = propertyInfo.GetCustomAttribute<UmbracoPropertyAttribute>();
                         if (umbracoPropertyAttr != null)
                         {
                             umbracoPropertyName = umbracoPropertyAttr.PropertyName;
@@ -76,28 +187,28 @@ namespace Our.Umbraco.Ditto
                             defaultValue = umbracoPropertyAttr.DefaultValue;
                         }
 
-                        // Try fetching the value
-                        var contentProperty = contentType.GetProperty(umbracoPropertyName);
-                        var propertyValue = contentProperty != null
-                            ? contentProperty.GetValue(content, null)
-                            : content.GetPropertyValue(umbracoPropertyName,
-                                recursive);
+                        // Try fetching the value.
+                        PropertyInfo contentProperty = contentType.GetProperty(umbracoPropertyName);
+                        object propertyValue = contentProperty != null
+                                                ? contentProperty.GetValue(content, null)
+                                                : content.GetPropertyValue(umbracoPropertyName, recursive);
 
-                        // Try fetching the alt value
+                        // Try fetching the alt value.
                         if (propertyValue == null && !string.IsNullOrWhiteSpace(altUmbracoPropertyName))
                         {
                             contentProperty = contentType.GetProperty(altUmbracoPropertyName);
                             propertyValue = contentProperty != null
-                                ? contentProperty.GetValue(content, null)
-                                : content.GetPropertyValue(altUmbracoPropertyName,
-                                    recursive);
+                                                ? contentProperty.GetValue(content, null)
+                                                : content.GetPropertyValue(altUmbracoPropertyName, recursive);
                         }
 
-                        // Try setting the default value
+                        // Try setting the default value.
                         if (propertyValue == null && defaultValue != null)
+                        {
                             propertyValue = defaultValue;
+                        }
 
-                        // Process the value
+                        // Process the value.
                         if (propertyValue != null)
                         {
                             if (propertyInfo.PropertyType.IsInstanceOfType(propertyValue))
@@ -108,15 +219,15 @@ namespace Our.Umbraco.Ditto
                             {
                                 using (DisposableTimer.DebugDuration(type, string.Format("TypeConverter ({0}, {1})", content.Id, propertyInfo.Name), "Complete"))
                                 {
-                                    var converterAttr = propertyInfo.GetCustomAttribute<TypeConverterAttribute>();
+                                    TypeConverterAttribute converterAttr = propertyInfo.GetCustomAttribute<TypeConverterAttribute>();
                                     if (converterAttr != null)
                                     {
-                                        var converter = Activator.CreateInstance(Type.GetType(converterAttr.ConverterTypeName)) as TypeConverter;
+                                        TypeConverter converter = Activator.CreateInstance(Type.GetType(converterAttr.ConverterTypeName)) as TypeConverter;
                                         propertyInfo.SetValue(instance, converter.ConvertFrom(propertyValue), null);
                                     }
                                     else
                                     {
-                                        var convert = propertyValue.TryConvertTo(propertyInfo.PropertyType);
+                                        Attempt<object> convert = propertyValue.TryConvertTo(propertyInfo.PropertyType);
                                         if (convert.Success)
                                         {
                                             propertyInfo.SetValue(instance, convert.Result, null);
@@ -128,7 +239,7 @@ namespace Our.Umbraco.Ditto
                     }
                 }
 
-                var args2 = new ConvertedTypeEventArgs
+                ConvertedTypeEventArgs args2 = new ConvertedTypeEventArgs
                 {
                     Content = content,
                     Converted = instance,
@@ -136,36 +247,13 @@ namespace Our.Umbraco.Ditto
                 };
 
                 if (convertedType != null)
+                {
                     convertedType(args2);
+                }
 
                 EventHandlers.CallConvertedTypeHandler(args2);
 
                 return args2.Converted;
-            }
-        }
-
-        public static T As<T>(this IPublishedContent content,
-            Action<ConvertingTypeEventArgs> convertingType = null,
-            Action<ConvertedTypeEventArgs> convertedType = null)
-            where T : class
-        {
-            return content.As(typeof(T), convertingType, convertedType) as T;
-        }
-
-        public static IEnumerable<T> As<T>(this IEnumerable<IPublishedContent> items,
-            string documentTypeAlias = null,
-            Action<ConvertingTypeEventArgs> convertingType = null,
-            Action<ConvertedTypeEventArgs> convertedType = null)
-            where T : class
-        {
-            using (DisposableTimer.DebugDuration<IEnumerable<T>>(string.Format("IEnumerable As ({0})", documentTypeAlias)))
-            {
-                if (string.IsNullOrWhiteSpace(documentTypeAlias))
-                    return items.Select(x => x.As<T>(convertingType, convertedType));
-
-                return items
-                    .Where(x => documentTypeAlias.InvariantEquals(x.DocumentTypeAlias))
-                    .Select(x => x.As<T>(convertingType, convertedType));
             }
         }
     }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentModelFactoryResolverExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentModelFactoryResolverExtensions.cs
@@ -1,16 +1,42 @@
-﻿using Umbraco.Core;
-using Umbraco.Core.Models;
-using Umbraco.Core.Models.PublishedContent;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="PublishedContentModelFactoryResolverExtensions.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   Encapsulates extension methods for <see cref="PublishedContentModelFactoryResolver" />.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.Extensions
 {
+    using System;
+    using System.Collections.Generic;
+
+    using global::Umbraco.Core;
+    using global::Umbraco.Core.Models;
+    using global::Umbraco.Core.Models.PublishedContent;
+
+    using Our.Umbraco.Ditto.ModelFactory;
+
+    /// <summary>
+    /// Encapsulates extension methods for <see cref="PublishedContentModelFactoryResolver"/>.
+    /// </summary>
     public static class PublishedContentModelFactoryResolverExtensions
     {
+        /// <summary>
+        /// Sets the factory resolver to resolve the given types using the <see cref="DittoPublishedContentModelFactory"/>.
+        /// </summary>
+        /// <param name="resolver">
+        /// The <see cref="PublishedContentModelFactoryResolver"/> this method extends.
+        /// </param>
+        /// <typeparam name="T">
+        /// The base <see cref="Type"/> to retrieve classes that inherit from.
+        /// </typeparam>
         public static void SetFactory<T>(this PublishedContentModelFactoryResolver resolver)
             where T : IPublishedContent
         {
-            var types = PluginManager.Current.ResolveTypes<T>();
-            var factory = new DittoPublishedContentModelFactory(types);
+            IEnumerable<Type> types = PluginManager.Current.ResolveTypes<T>();
+            DittoPublishedContentModelFactory factory = new DittoPublishedContentModelFactory(types);
 
             resolver.SetFactory(factory);
         }

--- a/src/Our.Umbraco.Ditto/Extensions/RenderModelExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/RenderModelExtensions.cs
@@ -1,18 +1,54 @@
-﻿using System;
-using Umbraco.Core;
-using Umbraco.Web.Models;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="RenderModelExtensions.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   Encapsulates extension methods for <see cref="RenderModel" />.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.Extensions
 {
+    using System;
+
+    using Our.Umbraco.Ditto.EventArgs;
+
+    using global::Umbraco.Core;
+    using global::Umbraco.Web.Models;
+
+    /// <summary>
+    /// Encapsulates extension methods for <see cref="RenderModel"/>.
+    /// </summary>
     public static class RenderModelExtensions
     {
-        public static T As<T>(this RenderModel model,
+        /// <summary>
+        /// Returns the given instance of <see cref="RenderModel"/> as the specified type.
+        /// </summary>
+        /// <param name="model">
+        /// The <see cref="RenderModel"/> to convert.
+        /// </param>
+        /// <param name="convertingType">
+        /// The <see cref="Action{ConvertingTypeEventArgs}"/> to fire when converting.
+        /// </param>
+        /// <param name="convertedType">
+        /// The <see cref="Action{ConvertedTypeEventArgs}"/> to fire when converted.
+        /// </param>
+        /// <typeparam name="T">
+        /// The <see cref="Type"/> of items to return.
+        /// </typeparam>
+        /// <returns>
+        /// The resolved <see cref="T"/>.
+        /// </returns>
+        public static T As<T>(
+            this RenderModel model,
             Action<ConvertingTypeEventArgs> convertingType = null,
             Action<ConvertedTypeEventArgs> convertedType = null)
             where T : RenderModel
         {
             if (model == null)
+            {
                 return default(T);
+            }
 
             using (DisposableTimer.DebugDuration<T>(string.Format("RenderModel As ({0})", model.Content.DocumentTypeAlias)))
             {

--- a/src/Our.Umbraco.Ditto/ModelFactory/DittoPublishedContentModelFactory.cs
+++ b/src/Our.Umbraco.Ditto/ModelFactory/DittoPublishedContentModelFactory.cs
@@ -1,19 +1,43 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Umbraco.Core;
-using Umbraco.Core.Models;
-using Umbraco.Core.Models.PublishedContent;
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DittoPublishedContentModelFactory.cs" company="Umbrella Inc, Our Umbraco and other contributors">
+//   Copyright Umbrella Inc, Our Umbraco and other contributors
+// </copyright>
+// <summary>
+//   The Ditto published content model factory for creating strong typed models.
+// </summary>
+// --------------------------------------------------------------------------------------------------------------------
 
-namespace Our.Umbraco.Ditto
+namespace Our.Umbraco.Ditto.ModelFactory
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Our.Umbraco.Ditto.Extensions;
+
+    using global::Umbraco.Core;
+    using global::Umbraco.Core.Models;
+    using global::Umbraco.Core.Models.PublishedContent;
+
+    /// <summary>
+    /// The Ditto published content model factory for creating strong typed models.
+    /// </summary>
     public class DittoPublishedContentModelFactory : IPublishedContentModelFactory
     {
-        private readonly Dictionary<string, Func<IPublishedContent, IPublishedContent>> _converters;
+        /// <summary>
+        /// The type converter cache.
+        /// </summary>
+        private readonly Dictionary<string, Func<IPublishedContent, IPublishedContent>> converterCache;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoPublishedContentModelFactory"/> class.
+        /// </summary>
+        /// <param name="types">
+        /// The <see cref="IEnumerable{Type}"/> to register for creation.
+        /// </param>
         public DittoPublishedContentModelFactory(IEnumerable<Type> types)
         {
-            var converters = new Dictionary<string, Func<IPublishedContent, IPublishedContent>>(StringComparer.InvariantCultureIgnoreCase);
+            Dictionary<string, Func<IPublishedContent, IPublishedContent>> converters = new Dictionary<string, Func<IPublishedContent, IPublishedContent>>(StringComparer.InvariantCultureIgnoreCase);
 
             foreach (var type in types.Where(x => typeof(IPublishedContent).IsAssignableFrom(x)))
             {
@@ -22,26 +46,40 @@ namespace Our.Umbraco.Ditto
                     return x.As(type) as IPublishedContent;
                 };
 
-                var attribute = type.GetCustomAttribute<PublishedContentModelAttribute>(false);
-                var typeName = attribute == null ? type.Name : attribute.ContentTypeAlias;
+                PublishedContentModelAttribute attribute = type.GetCustomAttribute<PublishedContentModelAttribute>(false);
+                string typeName = attribute == null ? type.Name : attribute.ContentTypeAlias;
 
                 if (!converters.ContainsKey(typeName))
+                {
                     converters.Add(typeName, func);
+                }
             }
 
-            _converters = converters.Count > 0 ? converters : null;
+            this.converterCache = converters.Count > 0 ? converters : null;
         }
 
+        /// <summary>
+        /// Creates a strongly-typed model representing a published content.
+        /// </summary>
+        /// <param name="content">The original published content.</param>
+        /// <returns>
+        /// The strongly-typed model representing the published content, or the published content
+        /// itself it the factory has no model for that content type.
+        /// </returns>
         public IPublishedContent CreateModel(IPublishedContent content)
         {
-            if (_converters == null)
+            if (this.converterCache == null)
+            {
                 return content;
+            }
 
-            var contentTypeAlias = content.DocumentTypeAlias;
+            string contentTypeAlias = content.DocumentTypeAlias;
             Func<IPublishedContent, IPublishedContent> converter;
 
-            if (!_converters.TryGetValue(contentTypeAlias, out converter))
+            if (!this.converterCache.TryGetValue(contentTypeAlias, out converter))
+            {
                 return content;
+            }
 
             // HACK: [LK:2014-07-24] Using the `RequestCache` to store the result, as the model-factory can be called multiple times per request.
             // The cache should only contain models have a corresponding converter, so in theory the result should be the same.

--- a/src/Our.Umbraco.Ditto/Settings.StyleCop
+++ b/src/Our.Umbraco.Ditto/Settings.StyleCop
@@ -1,0 +1,15 @@
+<StyleCopSettings Version="105">
+  <GlobalSettings>
+    <CollectionProperty Name="RecognizedWords">
+      <Value>Umbraco</Value>
+    </CollectionProperty>
+  </GlobalSettings>
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <AnalyzerSettings>
+        <StringProperty Name="CompanyName">Umbrella Inc, Our Umbraco and other contributors</StringProperty>
+        <StringProperty Name="Copyright">Copyright Umbrella Inc, Our Umbraco and other contributors</StringProperty>
+      </AnalyzerSettings>
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>


### PR DESCRIPTION
This commit does several things.
1. Adds xml documentation
2. Fixes braces, usings and naming conventions
3. Places classes in the correct respective namespaces.

I am aware that this breaks the layout of public methods and I know it's a big ask. 

I believe this is better for allowing further extension of the project and since it is still an early pre-release I think it is acceptable at this juncture.
