### PR TITLE
Property Value Null Checks

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -185,7 +185,8 @@
                                                 : content.GetPropertyValue(umbracoPropertyName, recursive);
 
                         // Try fetching the alt value.
-                        if (propertyValue == null && !string.IsNullOrWhiteSpace(altUmbracoPropertyName))
+                        if ((propertyValue == null || propertyValue.ToString().IsNullOrWhiteSpace()) 
+                            && !string.IsNullOrWhiteSpace(altUmbracoPropertyName))
                         {
                             contentProperty = contentType.GetProperty(altUmbracoPropertyName);
                             propertyValue = contentProperty != null
@@ -194,7 +195,8 @@
                         }
 
                         // Try setting the default value.
-                        if (propertyValue == null && defaultValue != null)
+                        if ((propertyValue == null || propertyValue.ToString().IsNullOrWhiteSpace())
+					        && defaultValue != null)
                         {
                             propertyValue = defaultValue;
                         }


### PR DESCRIPTION
I've updated the check on propertyValue to check for IsNullOrWhiteSpace() because GetPropertyValue
was returning an empty string rather than null therefore not using my AltPropertyName or the
DefaultValue if set.

Nice one,
Aaron ( - First pull request so go easy! Think I've done it right...)