### PR TITLE
Move the context cache hack

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -104,164 +104,197 @@
         /// <exception cref="InvalidOperationException">
         /// Thrown if the given type has invalid constructors.
         /// </exception>
-        internal static object As(
-            this IPublishedContent content,
-            Type type,
-            Action<ConvertingTypeEventArgs> convertingType = null,
-            Action<ConvertedTypeEventArgs> convertedType = null)
+        internal static object As(this IPublishedContent content, Type type, Action<ConvertingTypeEventArgs> convertingType = null, Action<ConvertedTypeEventArgs> convertedType = null)
         {
             if (content == null)
             {
                 return null;
             }
 
-            using (DisposableTimer.DebugDuration(type, string.Format("IPublishedContent As ({0})", content.DocumentTypeAlias), "Complete"))
-            {
-                var constructor = type.GetConstructors()
+            // HACK: [LK:2014-07-24] Using the `RequestCache` to store the result, as the model-factory can be called multiple times per request.
+            // The cache should only contain models have a corresponding converter, so in theory the result should be the same.
+            // Reason for caching, is that Ditto uses reflection to set property values, this can be a performance hit (especially when called multiple times).
+            //
+            // Update [JS:2015-01-08] Moved so that non model-factory implementations can use the cache and included the type name in the  
+            // cache key in case you are returning a base type and inherited type within the same request.
+            return ApplicationContext.Current.ApplicationCache.RequestCache.GetCacheItem(
+                    string.Format("Ditto.CreateModel_{0}_{1}", type.Name, content.Path),
+                    () =>
+                    {
+                        using (DisposableTimer.DebugDuration(type, string.Format("IPublishedContent As ({0})", content.DocumentTypeAlias), "Complete"))
+                        {
+                            // Check for and fire any event args
+                            var convertingArgs = new ConvertingTypeEventArgs
+                            {
+                                Content = content
+                            };
+
+                            EventHandlers.CallConvertingTypeHandler(convertingArgs);
+
+                            if (!convertingArgs.Cancel && convertingType != null)
+                            {
+                                convertingType(convertingArgs);
+                            }
+
+                            // Cancel if applicable. 
+                            if (convertingArgs.Cancel)
+                            {
+                                return null;
+                            }
+
+                            // Create an object and fetch it as the type.
+                            object instance = GetTypedProperty(content, type);
+
+                            // Fire the converted event
+                            var convertedArgs = new ConvertedTypeEventArgs
+                            {
+                                Content = content,
+                                Converted = instance,
+                                ConvertedType = type
+                            };
+
+                            if (convertedType != null)
+                            {
+                                convertedType(convertedArgs);
+                            }
+
+                            EventHandlers.CallConvertedTypeHandler(convertedArgs);
+
+                            return convertedArgs.Converted;
+                        }
+                    });
+        }
+
+        /// <summary>
+        /// Returns an object representing the given <see cref="Type"/>.
+        /// </summary>
+        /// <param name="content">
+        /// The <see cref="IPublishedContent"/> to convert.
+        /// </param>
+        /// <param name="type">
+        /// The <see cref="Type"/> of items to return.
+        /// </param>
+        /// <returns>
+        /// The converted <see cref="Object"/> as the given type.
+        /// </returns>
+        private static object GetTypedProperty(IPublishedContent content, Type type)
+        {
+            var constructor = type.GetConstructors()
                     .OrderBy(x => x.GetParameters().Length)
                     .First();
-                var constructorParams = constructor.GetParameters();
+            var constructorParams = constructor.GetParameters();
 
-                var args1 = new ConvertingTypeEventArgs { Content = content };
+            object instance;
+            if (constructorParams.Length == 0)
+            {
+                instance = Activator.CreateInstance(type);
+            }
+            else if (constructorParams.Length == 1 & constructorParams[0].ParameterType == typeof(IPublishedContent))
+            {
+                instance = Activator.CreateInstance(type, content);
+            }
+            else
+            {
+                throw new InvalidOperationException("Type {0} has invalid constructor parameters");
+            }
 
-                EventHandlers.CallConvertingTypeHandler(args1);
+            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var contentType = content.GetType();
 
-                if (!args1.Cancel && convertingType != null)
+            foreach (var propertyInfo in properties.Where(x => x.CanWrite))
+            {
+                using (DisposableTimer.DebugDuration(type, string.Format("ForEach Property ({1} {0})", propertyInfo.Name, content.Id), "Complete"))
                 {
-                    convertingType(args1);
-                }
-
-                if (args1.Cancel)
-                {
-                    return null;
-                }
-
-                object instance;
-                if (constructorParams.Length == 0)
-                {
-                    instance = Activator.CreateInstance(type);
-                }
-                else if (constructorParams.Length == 1 & constructorParams[0].ParameterType == typeof(IPublishedContent))
-                {
-                    instance = Activator.CreateInstance(type, content);
-                }
-                else
-                {
-                    throw new InvalidOperationException("Type {0} has invalid constructor parameters");
-                }
-
-                var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-                var contentType = content.GetType();
-
-                foreach (var propertyInfo in properties.Where(x => x.CanWrite))
-                {
-                    using (DisposableTimer.DebugDuration(type, string.Format("ForEach Property ({1} {0})", propertyInfo.Name, content.Id), "Complete"))
+                    // Check for the ignore attribute.
+                    var ignoreAttr = propertyInfo.GetCustomAttribute<DittoIgnoreAttribute>();
+                    if (ignoreAttr != null)
                     {
-                        // Check for the ignore attribute.
-                        var ignoreAttr = propertyInfo.GetCustomAttribute<DittoIgnoreAttribute>();
-                        if (ignoreAttr != null)
+                        continue;
+                    }
+
+                    var umbracoPropertyName = propertyInfo.Name;
+                    var altUmbracoPropertyName = string.Empty;
+                    var recursive = false;
+                    object defaultValue = null;
+
+                    var umbracoPropertyAttr = propertyInfo.GetCustomAttribute<UmbracoPropertyAttribute>();
+                    if (umbracoPropertyAttr != null)
+                    {
+                        umbracoPropertyName = umbracoPropertyAttr.PropertyName;
+                        altUmbracoPropertyName = umbracoPropertyAttr.AltPropertyName;
+                        recursive = umbracoPropertyAttr.Recursive;
+                        defaultValue = umbracoPropertyAttr.DefaultValue;
+                    }
+
+                    // Try fetching the value.
+                    var contentProperty = contentType.GetProperty(umbracoPropertyName);
+                    object propertyValue = contentProperty != null
+                                            ? contentProperty.GetValue(content, null)
+                                            : content.GetPropertyValue(umbracoPropertyName, recursive);
+
+                    // Try fetching the alt value.
+                    if (propertyValue == null && !string.IsNullOrWhiteSpace(altUmbracoPropertyName))
+                    {
+                        contentProperty = contentType.GetProperty(altUmbracoPropertyName);
+                        propertyValue = contentProperty != null
+                                            ? contentProperty.GetValue(content, null)
+                                            : content.GetPropertyValue(altUmbracoPropertyName, recursive);
+                    }
+
+                    // Try setting the default value.
+                    if (propertyValue == null && defaultValue != null)
+                    {
+                        propertyValue = defaultValue;
+                    }
+
+                    // Process the value.
+                    if (propertyValue != null)
+                    {
+                        // Try any custom type converters first. Check both on class or property.
+                        var converterAttribute = propertyInfo.GetCustomAttribute<TypeConverterAttribute>() ??
+                            (TypeConverterAttribute)propertyInfo.PropertyType.GetCustomAttributes().FirstOrDefault(a => a is TypeConverterAttribute);
+
+                        if (converterAttribute != null)
                         {
-                            continue;
-                        }
-
-                        var umbracoPropertyName = propertyInfo.Name;
-                        var altUmbracoPropertyName = string.Empty;
-                        var recursive = false;
-                        object defaultValue = null;
-
-                        var umbracoPropertyAttr = propertyInfo.GetCustomAttribute<UmbracoPropertyAttribute>();
-                        if (umbracoPropertyAttr != null)
-                        {
-                            umbracoPropertyName = umbracoPropertyAttr.PropertyName;
-                            altUmbracoPropertyName = umbracoPropertyAttr.AltPropertyName;
-                            recursive = umbracoPropertyAttr.Recursive;
-                            defaultValue = umbracoPropertyAttr.DefaultValue;
-                        }
-
-                        // Try fetching the value.
-                        var contentProperty = contentType.GetProperty(umbracoPropertyName);
-                        object propertyValue = contentProperty != null
-                                                ? contentProperty.GetValue(content, null)
-                                                : content.GetPropertyValue(umbracoPropertyName, recursive);
-
-                        // Try fetching the alt value.
-                        if (propertyValue == null && !string.IsNullOrWhiteSpace(altUmbracoPropertyName))
-                        {
-                            contentProperty = contentType.GetProperty(altUmbracoPropertyName);
-                            propertyValue = contentProperty != null
-                                                ? contentProperty.GetValue(content, null)
-                                                : content.GetPropertyValue(altUmbracoPropertyName, recursive);
-                        }
-
-                        // Try setting the default value.
-                        if (propertyValue == null && defaultValue != null)
-                        {
-                            propertyValue = defaultValue;
-                        }
-
-                        // Process the value.
-                        if (propertyValue != null)
-                        {
-                            // Try any custom type converters first. Check both on class or property.
-                            var converterAttribute = propertyInfo.GetCustomAttribute<TypeConverterAttribute>() ??
-                                (TypeConverterAttribute)propertyInfo.PropertyType.GetCustomAttributes().FirstOrDefault(a => a is TypeConverterAttribute);
-
-                            if (converterAttribute != null)
+                            if (converterAttribute.ConverterTypeName != null)
                             {
-                                if (converterAttribute.ConverterTypeName != null)
+                                // Time custom conversions.
+                                using (DisposableTimer.DebugDuration(type, string.Format("Custom TypeConverter ({0}, {1})", content.Id, propertyInfo.Name), "Complete"))
                                 {
-                                    // Time custom conversions.
-                                    using (DisposableTimer.DebugDuration(type, string.Format("Custom TypeConverter ({0}, {1})", content.Id, propertyInfo.Name), "Complete"))
+                                    // Get the custom converter from the attribute and attempt to convert.
+                                    var toConvert = Type.GetType(converterAttribute.ConverterTypeName);
+                                    if (toConvert != null)
                                     {
-                                        // Get the custom converter from the attribute and attempt to convert.
-                                        var toConvert = Type.GetType(converterAttribute.ConverterTypeName);
-                                        if (toConvert != null)
+                                        var converter = Activator.CreateInstance(toConvert) as TypeConverter;
+                                        if (converter != null)
                                         {
-                                            var converter = Activator.CreateInstance(toConvert) as TypeConverter;
-                                            if (converter != null)
-                                            {
-                                                propertyInfo.SetValue(instance, converter.ConvertFrom(propertyValue), null);
-                                            }
+                                            propertyInfo.SetValue(instance, converter.ConvertFrom(propertyValue), null);
                                         }
                                     }
                                 }
                             }
-                            else if (propertyInfo.PropertyType.IsInstanceOfType(propertyValue))
+                        }
+                        else if (propertyInfo.PropertyType.IsInstanceOfType(propertyValue))
+                        {
+                            // Simple types
+                            propertyInfo.SetValue(instance, propertyValue, null);
+                        }
+                        else
+                        {
+                            using (DisposableTimer.DebugDuration(type, string.Format("TypeConverter ({0}, {1})", content.Id, propertyInfo.Name), "Complete"))
                             {
-                                // Simple types
-                                propertyInfo.SetValue(instance, propertyValue, null);
-                            }
-                            else
-                            {
-                                using (DisposableTimer.DebugDuration(type, string.Format("TypeConverter ({0}, {1})", content.Id, propertyInfo.Name), "Complete"))
+                                var convert = propertyValue.TryConvertTo(propertyInfo.PropertyType);
+                                if (convert.Success)
                                 {
-                                    var convert = propertyValue.TryConvertTo(propertyInfo.PropertyType);
-                                    if (convert.Success)
-                                    {
-                                        propertyInfo.SetValue(instance, convert.Result, null);
-                                    }
+                                    propertyInfo.SetValue(instance, convert.Result, null);
                                 }
                             }
                         }
                     }
                 }
-
-                var args2 = new ConvertedTypeEventArgs
-                {
-                    Content = content,
-                    Converted = instance,
-                    ConvertedType = type
-                };
-
-                if (convertedType != null)
-                {
-                    convertedType(args2);
-                }
-
-                EventHandlers.CallConvertedTypeHandler(args2);
-
-                return args2.Converted;
             }
+
+            return instance;
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/ModelFactory/DittoPublishedContentModelFactory.cs
+++ b/src/Our.Umbraco.Ditto/ModelFactory/DittoPublishedContentModelFactory.cs
@@ -69,12 +69,8 @@
                 return content;
             }
 
-            // HACK: [LK:2014-07-24] Using the `RequestCache` to store the result, as the model-factory can be called multiple times per request.
-            // The cache should only contain models have a corresponding converter, so in theory the result should be the same.
-            // Reason for caching, is that Ditto uses reflection to set property values, this can be a performance hit (especially when called multiple times).
-            return (IPublishedContent)ApplicationContext.Current.ApplicationCache.RequestCache.GetCacheItem(
-                string.Concat("DittoPublishedContentModelFactory.CreateModel_", content.Path),
-                () => converter(content));
+            // No need to cache here as the extension method itself caches per request.
+            return converter(content);
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj.DotSettings
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj.DotSettings
@@ -1,5 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Attributes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=attributes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=EventArgs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=eventargs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Extensions/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=ModelFactory/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=ModelFactory/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=modelfactory/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Moved so that non model-factory implementations can use the request
cache and included the type name in the cache key in case you are
returning a base type and inherited type within the same request.

I also shifted the type conversion code into it's own method as it would
have been a nightmare to read within the function.

Resharper 9 seems to have changed casing for excluded namespace folders so that's why the dotsettings file has been altered.