### PR TITLE
Parse TypeConverter attributes on enumerables

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/TypeInferenceExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/TypeInferenceExtensions.cs
@@ -1,0 +1,104 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Extensions methods for <see cref="T:System.Type"/> for inferring type properties.
+    /// Most of this code was adapted from the Entity Framework
+    /// </summary>
+    public static class TypeInferenceExtensions
+    {
+        /// <summary>
+        /// Determines whether the specified type is a collection type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>True if the type is a collection type otherwise; false.</returns>
+        public static bool IsCollectionType(this Type type)
+        {
+            return type.TryGetElementType(typeof(ICollection<>)) != null;
+        }
+
+        /// <summary>
+        /// Determines whether the specified type is an enumerable type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>True if the type is an enumerable type otherwise; false.</returns>
+        public static bool IsEnumerableType(this Type type)
+        {
+            return type.TryGetElementType(typeof(IEnumerable<>)) != null;
+        }
+
+        /// <summary>
+        /// Determine if the given type implements the given generic interface or derives from the given generic type,
+        /// and if so return the element type of the collection. If the type implements the generic interface several times
+        /// <c>null</c> will be returned.
+        /// </summary>
+        /// <param name="type"> The type to examine. </param>
+        /// <param name="interfaceOrBaseType"> The generic type to be queried for. </param>
+        /// <returns> 
+        /// <c>null</c> if <paramref name="interfaceOrBaseType"/> isn't implemented or implemented multiple times,
+        /// otherwise the generic argument.
+        /// </returns>
+        public static Type TryGetElementType(this Type type, Type interfaceOrBaseType)
+        {
+            if (!type.IsGenericTypeDefinition())
+            {
+                Type[] types = GetGenericTypeImplementations(type, interfaceOrBaseType).ToArray();
+
+                return types.Length == 1 ? types[0].GetGenericArguments().FirstOrDefault() : null;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Determine if the given type implements the given generic interface or derives from the given generic type,
+        /// and if so return the concrete types implemented.
+        /// </summary>
+        /// <param name="type"> The type to examine. </param>
+        /// <param name="interfaceOrBaseType"> The generic type to be queried for. </param>
+        /// <returns> 
+        /// The generic types constructed from <paramref name="interfaceOrBaseType"/> and implemented by <paramref name="type"/>.
+        /// </returns>
+        public static IEnumerable<Type> GetGenericTypeImplementations(this Type type, Type interfaceOrBaseType)
+        {
+            if (!type.IsGenericTypeDefinition())
+            {
+                return (interfaceOrBaseType.IsInterface ? type.GetInterfaces() : type.GetBaseTypes())
+                        .Union(new[] { type })
+                        .Where(t => t.IsGenericType && t.GetGenericTypeDefinition() == interfaceOrBaseType);
+            }
+
+            return Enumerable.Empty<Type>();
+        }
+
+        /// <summary>
+        /// Gets the base types that the given type inherits from
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> to get the base types from.</param>
+        /// <returns>A collection of base types that the given type inherits from.</returns>
+        public static IEnumerable<Type> GetBaseTypes(this Type type)
+        {
+            type = type.BaseType;
+
+            while (type != null)
+            {
+                yield return type;
+
+                type = type.BaseType;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether the specified type is a generic type definition.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>True if the type represents a generic type definition; otherwise, false.</returns>
+        public static bool IsGenericTypeDefinition(this Type type)
+        {
+            return type.IsGenericTypeDefinition;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Compile Include="Attributes\DittoIgnoreAttribute.cs" />
     <Compile Include="Attributes\UmbracoPropertyAttribute.cs" />
+    <Compile Include="Extensions\TypeInferenceExtensions.cs" />
     <Compile Include="Extensions\TypeInitializationExtensions.cs" />
     <Compile Include="Extensions\PublishedContentModelFactoryResolverExtensions.cs" />
     <Compile Include="ModelFactory\DittoPublishedContentModelFactory.cs" />


### PR DESCRIPTION
This addition allows us to detect custom TypeConverter attributes for enumerable types. This lets us add the TypeConverter attribute to the type argument class itself rather than each property which dramatically cuts down fluff. 

Adding the TypeConverter attribute to the property will override any attributes bound to classes.

E.g

```
[TypeConverter(typeof(FooConverter))]
public class Foo
{
    // Properties here
}

public class Bar
{
    // This property will automatically map
    public IEnumerable<Foo> Foos { get; set; }
}
```