### PR TITLE
Added support for Umbraco Dictionary Item values.

### DIFF
--- a/src/Our.Umbraco.Ditto/Attributes/UmbracoDictionaryValueAttribute.cs
+++ b/src/Our.Umbraco.Ditto/Attributes/UmbracoDictionaryValueAttribute.cs
@@ -1,0 +1,28 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+
+    /// <summary>
+    /// The Umbraco dictionary value attribute.
+    /// Used for providing Umbraco with additional information about a dictionary item to aid property value conversion.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class UmbracoDictionaryValueAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoDictionaryValueAttributeAttribute"/> class.
+        /// </summary>
+        /// <param name="dictionaryKey">
+        /// The dictionary key.
+        /// </param>
+        public UmbracoDictionaryValueAttribute(string dictionaryKey)
+        {
+            this.DictionaryKey = dictionaryKey;
+        }
+
+        /// <summary>
+        /// Gets or sets the dictionary key.
+        /// </summary>
+        public string DictionaryKey { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -31,11 +31,6 @@
             = new ConcurrentDictionary<Type, PropertyInfo[]>();
 
         /// <summary>
-        /// Stores a private instance of <see cref="Umbraco.Web.UmbracoHelper"/>.
-        /// </summary>
-        private static UmbracoHelper UmbracoHelper;
-
-        /// <summary>
         /// Returns the given instance of <see cref="IPublishedContent"/> as the specified type.
         /// </summary>
         /// <param name="content">
@@ -281,14 +276,7 @@
                         var dictionaryValueAttr = propertyInfo.GetCustomAttribute<UmbracoDictionaryValueAttribute>();
                         if (dictionaryValueAttr != null && !dictionaryValueAttr.DictionaryKey.IsNullOrWhiteSpace())
                         {
-                            // HACK: [LK:2015-01-23] This feels hacky. I'd prefer to use `CultureDictionaryFactoryResolver`,
-                            // but it was marked as `internal` until v7.2.0
-                            if (UmbracoHelper == null)
-                            {
-                                UmbracoHelper = new UmbracoHelper(UmbracoContext.Current);
-                            }
-
-                            propertyValue = UmbracoHelper.GetDictionaryValue(dictionaryValueAttr.DictionaryKey);
+                            propertyValue = ConverterHelper.UmbracoHelper.GetDictionaryValue(dictionaryValueAttr.DictionaryKey);
                         }
                     }
 

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -31,6 +31,11 @@
             = new ConcurrentDictionary<Type, PropertyInfo[]>();
 
         /// <summary>
+        /// Stores a private instance of <see cref="Umbraco.Web.UmbracoHelper"/>.
+        /// </summary>
+        private static UmbracoHelper UmbracoHelper;
+
+        /// <summary>
         /// Returns the given instance of <see cref="IPublishedContent"/> as the specified type.
         /// </summary>
         /// <param name="content">
@@ -268,6 +273,23 @@
                         && defaultValue != null)
                     {
                         propertyValue = defaultValue;
+                    }
+
+                    // Check if a dictionary item has been assigned
+                    if (propertyValue == null || propertyValue.ToString().IsNullOrWhiteSpace())
+                    {
+                        var dictionaryValueAttr = propertyInfo.GetCustomAttribute<UmbracoDictionaryValueAttribute>();
+                        if (dictionaryValueAttr != null && !dictionaryValueAttr.DictionaryKey.IsNullOrWhiteSpace())
+                        {
+                            // HACK: [LK:2015-01-23] This feels hacky. I'd prefer to use `CultureDictionaryFactoryResolver`,
+                            // but it was marked as `internal` until v7.2.0
+                            if (UmbracoHelper == null)
+                            {
+                                UmbracoHelper = new UmbracoHelper(UmbracoContext.Current);
+                            }
+
+                            propertyValue = UmbracoHelper.GetDictionaryValue(dictionaryValueAttr.DictionaryKey);
+                        }
                     }
 
                     // Process the value.

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -62,6 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\DittoIgnoreAttribute.cs" />
+    <Compile Include="Attributes\UmbracoDictionaryValueAttribute.cs" />
     <Compile Include="Attributes\UmbracoPropertyAttribute.cs" />
     <Compile Include="ComponentModel\TypeConverters\MultiNodeTreePickerConverter.cs" />
     <Compile Include="ComponentModel\TypeConverters\MultipleMediaPickerConverter.cs" />


### PR DESCRIPTION
Added support for Umbraco Dictionary Item values.

I'm not 100% happy about having a private static field for `UmbracoHelper`, but I didn't want to create a new instance for each property mapping - otherwise the Dictionary lookup may hit the database multiple times.

// @JimBobSquarePants - feel free to add suggestions