### PR TITLE
TypeInitializationExtensions - use DependencyResolver?

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/TypeInitializationExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/TypeInitializationExtensions.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Web.Mvc;
 
     /// <summary>
     /// Extensions methods for <see cref="T:System.Type"/> for creating instances of types faster than 
@@ -21,7 +22,7 @@
         public static object GetInstance(this Type type)
         {
             // This is about as quick as it gets.
-            return Activator.CreateInstance(type);
+            return DependencyResolver.Current.GetService(type);
         }
 
         /// <summary>


### PR DESCRIPTION
@JimBobSquarePants - Following on from #20 - do you see any issue with us swapping out using `Activator` with `DependencyResolver`?