### PR TITLE
Adding built in TypeConverters

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConverterHelper.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConverterHelper.cs
@@ -1,0 +1,27 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using global::Umbraco.Core;
+    using global::Umbraco.Web;
+
+    /// <summary>
+    /// Provides helper methods to aid with conversion. Not much in here for now but who knows 
+    /// what the future has in store?
+    /// </summary>
+    internal static class ConverterHelper
+    {
+        /// <summary>
+        /// Gets the <see cref="UmbracoHelper"/> for querying published content or media.
+        /// </summary>
+        public static UmbracoHelper UmbracoHelper
+        {
+            get
+            {
+                // Pull the item from the cache if possible to reduce the db access overhead caused by 
+                // multiple reflection iterations for the given type taking place in a single request.
+                return (UmbracoHelper)ApplicationContext.Current.ApplicationCache.RequestCache.GetCacheItem(
+                        "Ditto.UmbracoHelper",
+                        () => new UmbracoHelper(UmbracoContext.Current));
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/ContentPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/ContentPickerConverter.cs
@@ -1,0 +1,66 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+
+    using global::Umbraco.Core.Models.PublishedContent;
+    using global::Umbraco.Web;
+
+    /// <summary>
+    /// Provides a unified way of converting content picker properties to strong typed model.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The <see cref="Type"/> of the object to return.
+    /// </typeparam>
+    public class ContentPickerConverter<T> : TypeConverter where T : PublishedContentModel
+    {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            // Handle both selected and empty states.
+            if (sourceType == typeof(string) || sourceType == typeof(int))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            int nodeId = Convert.ToInt32(value);
+
+            if (nodeId > 0)
+            {
+                UmbracoHelper umbracoHelper = ConverterHelper.UmbracoHelper;
+                T document = umbracoHelper.TypedContent(nodeId).As<T>();
+
+                return document;
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/HtmlStringConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/HtmlStringConverter.cs
@@ -1,0 +1,81 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Web;
+
+    using global::Umbraco.Web;
+    using global::Umbraco.Web.Templates;
+
+    /// <summary>
+    /// Provides a unified way of converting <see cref="String"/>s to <see cref="HtmlString"/>'s.
+    /// </summary>
+    public class HtmlStringConverter : TypeConverter
+    {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter,
+        /// using the specified context.
+        /// </summary>
+        /// <param name="context">
+        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
+        /// </param>
+        /// <param name="sourceType">
+        /// A <see cref="T:System.Type" /> that represents the type you want to convert from.
+        /// </param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string) || sourceType == typeof(HtmlString))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            string s = value.ToString();
+            if (value is HtmlString)
+            {
+                if (!string.IsNullOrWhiteSpace(s))
+                {
+                    s = TemplateUtilities.ParseInternalLinks(s);
+                }
+
+                return new HtmlString(s);
+            }
+
+            // This lets us convert textbox multiple data type properties to HtmlString's 
+            if (value is string)
+            {
+                if (!string.IsNullOrWhiteSpace(s))
+                {
+                    UmbracoHelper umbracoHelper = ConverterHelper.UmbracoHelper;
+                    s = umbracoHelper.ReplaceLineBreaksForHtml(s);
+                }
+
+                return new HtmlString(s);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MediaPickerConverter.cs
@@ -1,0 +1,65 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+
+    using global::Umbraco.Core.Models.PublishedContent;
+    using global::Umbraco.Web;
+
+    /// <summary>
+    /// Provides a unified way of converting media picker properties to strong typed model.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The <see cref="Type"/> of the object to return.
+    /// </typeparam>
+    public class MediaPickerConverter<T> : TypeConverter where T : PublishedContentModel
+    {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string) || sourceType == typeof(int))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            int nodeId = Convert.ToInt32(value);
+
+            if (nodeId > 0)
+            {
+                UmbracoHelper umbracoHelper = ConverterHelper.UmbracoHelper;
+                T media = umbracoHelper.TypedMedia(nodeId).As<T>();
+
+                return media;
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultiNodeTreePickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultiNodeTreePickerConverter.cs
@@ -1,0 +1,124 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Linq;
+
+    using global::Umbraco.Core.Models;
+    using global::Umbraco.Core.Models.PublishedContent;
+    using global::Umbraco.Web;
+
+    /// <summary>
+    /// Provides a unified way of converting multi node tree picker properties to strong typed collections.
+    /// Adapted from <see href="https://github.com/Jeavon/Umbraco-Core-Property-Value-Converters/blob/v2/Our.Umbraco.PropertyConverters/MultiNodeTreePickerPropertyConverter.cs"/>
+    /// </summary>
+    /// <typeparam name="T">
+    /// The <see cref="Type"/> of the node to return.
+    /// </typeparam>
+    public class MultiNodeTreePickerConverter<T> : TypeConverter where T : PublishedContentModel
+    {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            // Handle both selected and empty states.
+            if (sourceType == typeof(string) || sourceType == typeof(int))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+            {
+                return Enumerable.Empty<T>();
+            }
+
+            string s = value as string ?? value.ToString();
+            if (!string.IsNullOrWhiteSpace(s))
+            {
+                IEnumerable<T> multiNodeTreePicker = Enumerable.Empty<T>();
+                int[] nodeIds = s.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToArray();
+
+                if (nodeIds.Any())
+                {
+                    UmbracoHelper umbracoHelper = ConverterHelper.UmbracoHelper;
+                    UmbracoObjectTypes objectType = UmbracoObjectTypes.Unknown;
+                    List<T> temp = new List<T>();
+
+                    // Oh so ugly if you let Resharper do this.
+                    // ReSharper disable once LoopCanBeConvertedToQuery
+                    foreach (int nodeId in nodeIds)
+                    {
+                        IPublishedContent item = this.GetPublishedContent(nodeId, ref objectType, UmbracoObjectTypes.Document, umbracoHelper.TypedContent)
+                             ?? this.GetPublishedContent(nodeId, ref objectType, UmbracoObjectTypes.Media, umbracoHelper.TypedMedia)
+                             ?? this.GetPublishedContent(nodeId, ref objectType, UmbracoObjectTypes.Member, umbracoHelper.TypedMember);
+
+                        if (item != null)
+                        {
+                            temp.Add(item.As<T>());
+                        }
+                    }
+
+                    // Don't return the list, instead use 'Skip' to return an iterator that can't be cast back and mutated.
+                    multiNodeTreePicker = temp.Skip(0);
+                }
+
+                return multiNodeTreePicker;
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        /// <summary>
+        /// Attempt to get an <see cref="IPublishedContent"/> instance based on id and object type.
+        /// </summary>
+        /// <param name="nodeId">The content node ID</param>
+        /// <param name="actual">The type of content being requested</param>
+        /// <param name="expected">The type of content expected/supported by <paramref name="typedMethod"/></param>
+        /// <param name="typedMethod">A function to fetch content of type <paramref name="expected"/></param>
+        /// <returns>
+        /// The requested content, or null if either it does not exist or <paramref name="actual"/> does not 
+        /// match <paramref name="expected"/>
+        /// </returns>
+        private IPublishedContent GetPublishedContent(int nodeId, ref UmbracoObjectTypes actual, UmbracoObjectTypes expected, Func<int, IPublishedContent> typedMethod)
+        {
+            // Is the given type supported by the typed method.
+            if (actual != UmbracoObjectTypes.Unknown && actual != expected)
+            {
+                return null;
+            }
+
+            // Attempt to get the content
+            IPublishedContent content = typedMethod(nodeId);
+            if (content != null)
+            {
+                // If we find the content, assign the expected type to the actual type so we don't have to 
+                // keep looking for other types of content.
+                actual = expected;
+            }
+
+            return content;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultipleMediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultipleMediaPickerConverter.cs
@@ -1,0 +1,73 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Linq;
+
+    using global::Umbraco.Core.Models.PublishedContent;
+    using global::Umbraco.Web;
+
+    /// <summary>
+    /// Provides a unified way of converting multi media picker properties to strong typed collections.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The <see cref="Type"/> of the node to return.
+    /// </typeparam>
+    public class MultipleMediaPickerConverter<T> : TypeConverter where T : PublishedContentModel
+    {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter, using the specified context.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="sourceType">A <see cref="T:System.Type" /> that represents the type you want to convert from.</param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+            {
+                return Enumerable.Empty<T>();
+            }
+
+            string s = value as string;
+            if (!string.IsNullOrWhiteSpace(s))
+            {
+                IEnumerable<T> multiNodeTreePicker = Enumerable.Empty<T>();
+                int[] nodeIds = s.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+                                 .Select(int.Parse).ToArray();
+
+                if (nodeIds.Any())
+                {
+                    UmbracoHelper umbracoHelper = ConverterHelper.UmbracoHelper;
+                    multiNodeTreePicker = umbracoHelper.TypedMedia(nodeIds).Where(x => x != null).As<T>();
+                }
+
+                return multiNodeTreePicker;
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -6,6 +6,7 @@
     using System.ComponentModel;
     using System.Linq;
     using System.Reflection;
+    using System.Web;
     using System.Web.Mvc;
 
     using global::Umbraco.Core;
@@ -310,6 +311,12 @@
                                     }
                                 }
                             }
+                        }
+                        else if (propertyInfo.PropertyType == typeof(HtmlString))
+                        {
+                            // Handle Html strings so we don't have to set the attribute.
+                            HtmlStringConverter converter = new HtmlStringConverter();
+                            propertyInfo.SetValue(instance, converter.ConvertFrom(propertyValue), null);
                         }
                         else if (propertyInfo.PropertyType.IsInstanceOfType(propertyValue))
                         {

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -63,6 +63,12 @@
   <ItemGroup>
     <Compile Include="Attributes\DittoIgnoreAttribute.cs" />
     <Compile Include="Attributes\UmbracoPropertyAttribute.cs" />
+    <Compile Include="ComponentModel\TypeConverters\MultiNodeTreePickerConverter.cs" />
+    <Compile Include="ComponentModel\TypeConverters\MultipleMediaPickerConverter.cs" />
+    <Compile Include="ComponentModel\TypeConverters\MediaPickerConverter.cs" />
+    <Compile Include="ComponentModel\TypeConverters\ContentPickerConverter.cs" />
+    <Compile Include="ComponentModel\ConverterHelper.cs" />
+    <Compile Include="ComponentModel\TypeConverters\HtmlStringConverter.cs" />
     <Compile Include="Extensions\TypeInferenceExtensions.cs" />
     <Compile Include="Extensions\TypeInitializationExtensions.cs" />
     <Compile Include="Extensions\PublishedContentModelFactoryResolverExtensions.cs" />
@@ -78,6 +84,7 @@
   <ItemGroup>
     <Content Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj.DotSettings
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj.DotSettings
@@ -1,6 +1,8 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Attributes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=attributes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel_005Ctypeconverters/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=EventArgs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=eventargs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Extensions/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This adds the following converters:

- HtmlStringConverter
- ContentPickerConverter
- MediaPickerConverter
- MultipleMediaPickerConverter
- MultiNodeTreePickerConverter

Additionally a helper class has been added (internally for now) that aids with the conversion process by supplying a per-request-cached `UmbracoHelper` instance.

I've also made `HtmlString` conversion part of the default conversion pipeline. It makes more sense to me to have this run automatically than to add an attribute to the property each time.