### PR TITLE
Hotfix 0.5.1

### DIFF
--- a/BuildPackage/Build.bat
+++ b/BuildPackage/Build.bat
@@ -4,4 +4,4 @@ ECHO APPVEYOR_BUILD_NUMBER : %APPVEYOR_BUILD_NUMBER%
 ECHO APPVEYOR_BUILD_VERSION : %APPVEYOR_BUILD_VERSION%
 cd ..\BuildPackage\
 Call Tools\nuget.exe restore ..\Src\Our.Umbraco.Ditto.sln
-Call "%programfiles(x86)%\MSBuild\12.0\Bin\MsBuild.exe" package.proj
+Call "%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe" package.proj

--- a/BuildPackage/package.proj
+++ b/BuildPackage/package.proj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Package">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Package" ToolsVersion="4.0">
 
 	<!-- IMPORTS -->
 	<PropertyGroup>
@@ -88,14 +88,14 @@
 
 	<!-- COMPILE -->
 	<Target Name="Compile" DependsOnTargets="UpdateAssemblyInfo">
-		<MSBuild Projects="$(CoreProjectDir)\Our.Umbraco.Ditto.csproj" />
+		<MSBuild Projects="$(CoreProjectDir)\Our.Umbraco.Ditto.csproj" Properties="Configuration=Release" />
 	</Target>
 
 	<!-- PREPARE FILES -->
 	<Target Name="PrepairFiles" DependsOnTargets="Compile">
 		<ItemGroup>
-			<BinFiles Include="$(CoreProjectDir)\Bin\Debug\Our.Umbraco.Ditto.dll" />
-			<PackageFile Include="$(MSBuildProjectDirectory)\Package.xml" />
+			<BinFiles Include="$(CoreProjectDir)\Bin\Release\Our.Umbraco.Ditto.dll" />
+			<PackageFile Include="$(MSBuildProjectDirectory)\package.xml" />
 			<NuSpecFile Include="$(MSBuildProjectDirectory)\package.nuspec" />
 		</ItemGroup>
 		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(BuildDir)\bin" />
@@ -107,7 +107,7 @@
 	<!-- MANIFEST UMBRACO -->
 	<Target Name="ManifestUmbraco" DependsOnTargets="PrepairFiles">
 		<ItemGroup>
-			<ManifestFiles Include="$(BuildDir)\**\*" Exclude="$(BuildDir)\Package.xml" />
+			<ManifestFiles Include="$(BuildDir)\**\*" Exclude="$(BuildDir)\package.xml" />
 		</ItemGroup>
 		<ManifestUpdate
 			ManifestFile="$(BuildDir)\package.xml"

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -37,12 +37,13 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
-      <Private>False</Private>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.40804.0\lib\net40\System.Web.Mvc.dll</HintPath>
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.20710.0\lib\net40\System.Web.Mvc.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="umbraco">

--- a/src/Our.Umbraco.Ditto/Properties/VersionInfo.cs
+++ b/src/Our.Umbraco.Ditto/Properties/VersionInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("0.5.*")]
-[assembly: AssemblyInformationalVersion("0.5.0")]
+[assembly: AssemblyInformationalVersion("0.5.1")]
 
 

--- a/src/Our.Umbraco.Ditto/packages.config
+++ b/src/Our.Umbraco.Ditto/packages.config
@@ -7,7 +7,7 @@
   <package id="ImageProcessor" version="1.9.0.0" targetFramework="net45" />
   <package id="ImageProcessor.Web" version="3.2.3.0" targetFramework="net45" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Mvc" version="4.0.40804.0" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="4.0.30506.0" targetFramework="net45" />


### PR DESCRIPTION
Reverted the System.Web.Mvc dependency from v4.0.0.1 back to v4.0.0.0.
As this is causing issues with environments that have not yet been patched with v4.0.0.1 yet.

This patch should resolve issue #27.