### PR TITLE
Adding support for SymbolSource for both NuGet and MyGet

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ deploy:
      # MyGet Deployment for builds & releases
   - provider: NuGet
     server: https://www.myget.org/F/umbraco-ditto/
+    symbol_server: https://nuget.symbolsource.org/MyGet/umbraco-ditto
     api_key:
       secure: Q1/4K8VSwr7BjwmKDTef8y5lOc7S+jK9ELuWy67y6OVRpjxmnF9M3Gfs1kT+ir8x
     artifact: /.*\.nupkg/

--- a/build/package.proj
+++ b/build/package.proj
@@ -102,13 +102,18 @@
 	<Target Name="PrepareFiles" DependsOnTargets="Compile">
 		<ItemGroup>
 			<BinFiles Include="$(CoreProjectDir)\bin\$(BuildConfig)\Our.Umbraco.Ditto.dll" />
-			<PackageFile Include="$(MSBuildProjectDirectory)\package.xml" />
+      <PdbFiles Include="$(CoreProjectDir)\bin\$(BuildConfig)\Our.Umbraco.Ditto.pdb" />
+      <SrcFiles Include="$(CoreProjectDir)\**\*.cs" Exclude="$(CoreProjectDir)\obj\**"/>
+      <PackageFile Include="$(MSBuildProjectDirectory)\package.xml" />
 			<NuSpecFile Include="$(MSBuildProjectDirectory)\package.nuspec" />
 		</ItemGroup>
 		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(BuildUmbDir)\bin" />
 		<Copy SourceFiles="@(PackageFile)" DestinationFolder="$(BuildUmbDir)" />
 		<Copy SourceFiles="@(BinFiles)" DestinationFolder="$(BuildNuGetDir)\lib\net45" />
-		<Copy SourceFiles="@(NuSpecFile)" DestinationFolder="$(BuildNuGetDir)" />
+    <Copy SourceFiles="@(PdbFiles)" DestinationFolder="$(BuildNuGetDir)\lib\net45" />
+    <Copy SourceFiles="@(SrcFiles)"
+   DestinationFiles="@(SrcFiles->'$(BuildNuGetDir)\src\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(NuSpecFile)" DestinationFolder="$(BuildNuGetDir)" />
 	</Target>
 
 	<!-- MANIFEST UMBRACO -->
@@ -172,7 +177,8 @@
 			ManifestFile="$(BuildNuGetDir)\package.nuspec"
 			BasePath="$(BuildNuGetDir)"
 			Version="$(ProductVersion)"
-			OutputDirectory="$(ArtifactsDir)" />
+			OutputDirectory="$(ArtifactsDir)"
+      Symbols="true" />
 
 		<RemoveDir Directories="$(BuildUmbDir)" Condition="Exists('$(BuildUmbDir)')" />
 		<RemoveDir Directories="$(BuildNuGetDir)" Condition="Exists('$(BuildNuGetDir)')" />


### PR DESCRIPTION
This will cause the build scripts to generate both a .nupkg and a symbols.nupkg.

The nupkg will contain exactly the same contents as it does currently, the symbols.nupkg will additionally contain the pdb file and all cs files, this package will be automatically pushed to symbolsource.org (no config needed) and Visual Studio will be able to debug if set to use symbol servers!