### PR TITLE
Adding archetype support to Ditto

### DIFF
--- a/src/Our.Umbraco.Ditto.Tests/Extensions/TypeInferenceExtensionsTests.cs
+++ b/src/Our.Umbraco.Ditto.Tests/Extensions/TypeInferenceExtensionsTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Our.Umbraco.Ditto.Models.Archetype;
+using Our.Umbraco.Ditto.Models.Archetype.Abstract;
+
+namespace Our.Umbraco.Ditto.Tests.Extensions
+{
+    [TestFixture]
+    public class TypeInferenceExtensionsTests
+    {
+        [TestCase("TestClass", Result = true, TestName = "Get type from base type and string of classname")]
+        public bool FindClassesInAssembly(string name)
+        {
+            var stopwatch = new Stopwatch();
+
+            stopwatch.Start();
+
+            var result = TypeInferenceExtensions.GetTypeByName(name, typeof (ArchetypeModel)).Any();
+
+            stopwatch.Stop();
+
+            Console.WriteLine("took {0}ms to complete", stopwatch.ElapsedMilliseconds);
+
+            return result;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto.Tests/Models/TestClass.cs
+++ b/src/Our.Umbraco.Ditto.Tests/Models/TestClass.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Our.Umbraco.Ditto.Models.Archetype.Abstract;
+
+namespace Our.Umbraco.Ditto.Tests.Models
+{
+    public class TestClass : ArchetypeModel
+    {
+    }
+}

--- a/src/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/src/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{956A042E-6DF1-4157-9D61-4CE9EF90263B}</ProjectGuid>
+    <ProjectGuid>{A64197BB-B054-4E08-99E0-7029424FA4D2}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Our.Umbraco.Ditto.ModelFactory</RootNamespace>
-    <AssemblyName>Our.Umbraco.Ditto.ModelFactory</AssemblyName>
+    <RootNamespace>Our.Umbraco.Ditto.Tests</RootNamespace>
+    <AssemblyName>Our.Umbraco.Ditto.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -32,39 +32,35 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <Private>False</Private>
-      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.40804.0\lib\net40\System.Web.Mvc.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="umbraco">
+    <Reference Include="umbraco, Version=1.0.5529.18525, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.dll</HintPath>
-    </Reference>
-    <Reference Include="Umbraco.Core">
-      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Umbraco.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DittoPublishedContentModelFactory.cs" />
-    <Compile Include="Extensions\PublishedContentModelFactoryResolverExtensions.cs" />
+    <Compile Include="Extensions\TypeInferenceExtensionsTests.cs" />
+    <Compile Include="Models\TestClass.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Our.Umbraco.Ditto\Our.Umbraco.Ditto.csproj">
+    <ProjectReference Include="..\..\..\..\mlwd\umbraco-ditto\src\Our.Umbraco.Ditto\Our.Umbraco.Ditto.csproj">
       <Project>{3a2482a4-ad19-4c26-a449-4287da07ab16}</Project>
       <Name>Our.Umbraco.Ditto</Name>
-      <Private>False</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Our.Umbraco.Ditto.Tests/Properties/AssemblyInfo.cs
+++ b/src/Our.Umbraco.Ditto.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Our.Umbraco.Ditto.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Our.Umbraco.Ditto.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ce629528-ca0a-44bf-9e99-85bdb68af304")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Our.Umbraco.Ditto.Tests/packages.config
+++ b/src/Our.Umbraco.Ditto.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+</packages>

--- a/src/Our.Umbraco.Ditto.sln
+++ b/src/Our.Umbraco.Ditto.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Package", "Build Pack
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.Ditto.ModelFactory", "Our.Umbraco.Ditto.ModelFactory\Our.Umbraco.Ditto.ModelFactory.csproj", "{956A042E-6DF1-4157-9D61-4CE9EF90263B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.Ditto.Tests", "Our.Umbraco.Ditto.Tests\Our.Umbraco.Ditto.Tests.csproj", "{A64197BB-B054-4E08-99E0-7029424FA4D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{956A042E-6DF1-4157-9D61-4CE9EF90263B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{956A042E-6DF1-4157-9D61-4CE9EF90263B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{956A042E-6DF1-4157-9D61-4CE9EF90263B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A64197BB-B054-4E08-99E0-7029424FA4D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A64197BB-B054-4E08-99E0-7029424FA4D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A64197BB-B054-4E08-99E0-7029424FA4D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A64197BB-B054-4E08-99E0-7029424FA4D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Our.Umbraco.Ditto/Attributes/UmbracoPropertyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/Attributes/UmbracoPropertyAttribute.cs
@@ -24,12 +24,13 @@
         /// <param name="defaultValue">
         /// The default value.
         /// </param>
-        public UmbracoPropertyAttribute(string propertyName, string altPropertyName = "", bool recursive = false, object defaultValue = null)
+        public UmbracoPropertyAttribute(string propertyName, string altPropertyName = "", bool recursive = false, object defaultValue = null, bool isArchetype = false)
         {
             this.PropertyName = propertyName;
             this.AltPropertyName = altPropertyName;
             this.Recursive = recursive;
             this.DefaultValue = defaultValue;
+            this.IsArchetype = false;
         }
 
         /// <summary>
@@ -51,5 +52,10 @@
         /// Gets or sets the default value.
         /// </summary>
         public object DefaultValue { get; set; }
+
+        /// <summary>
+        /// Defines if property is an Archetype
+        /// </summary>
+        public bool IsArchetype { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultiNodeTreePickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultiNodeTreePickerConverter.cs
@@ -100,7 +100,9 @@
                 return multiNodeTreePicker;
             }
 
-            return base.ConvertFrom(context, culture, value);
+            // [ML] - return default list as its always nice to avoid null reference exceptions on lists =)
+
+            return Enumerable.Empty<T>();
         }
 
         /// <summary>

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultipleMediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultipleMediaPickerConverter.cs
@@ -89,7 +89,7 @@
                 return multiNodeTreePicker;
             }
 
-            return base.ConvertFrom(context, culture, value);
+            return Enumerable.Empty<T>();
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/UltimatePickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/UltimatePickerConverter.cs
@@ -97,7 +97,7 @@
                 }
             }
 
-            return base.ConvertFrom(context, culture, value);
+            return Enumerable.Empty<T>();
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Models/Archetype/Abstract/ArchetypeModel.cs
+++ b/src/Our.Umbraco.Ditto/Models/Archetype/Abstract/ArchetypeModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.Ditto.Models.Archetype.Abstract
+{
+    public class ArchetypeModel
+    {
+        public string Alias { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Models/Archetype/ArchetypeCMSModel.cs
+++ b/src/Our.Umbraco.Ditto/Models/Archetype/ArchetypeCMSModel.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Our.Umbraco.Ditto.Models.Archetype
+{
+    public class ArchetypeCMSModel
+    {
+        [JsonProperty("fieldsets")]
+        public Fieldset[] Fieldsets { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Models/Archetype/FieldsetModel.cs
+++ b/src/Our.Umbraco.Ditto/Models/Archetype/FieldsetModel.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Our.Umbraco.Ditto.Models.Archetype
+{
+    public class Fieldset
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("properties")]
+        public PropertyModel[] Properties { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Models/Archetype/PropertyModel.cs
+++ b/src/Our.Umbraco.Ditto/Models/Archetype/PropertyModel.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Our.Umbraco.Ditto.Models.Archetype
+{
+    public class PropertyModel
+    {
+        [JsonProperty("alias")]
+        public string Alias { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -32,6 +32,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="interfaces">
+      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="MiniProfiler">
+      <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.0.5.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System">
       <Private>False</Private>
     </Reference>
@@ -39,18 +49,6 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Web">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="interfaces">
-      <HintPath>..\packages\UmbracoCms.Core.6.2.5\lib\interfaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MiniProfiler">
-      <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -69,12 +67,10 @@
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
     </Reference>
     <Reference Include="umbraco">
-      <HintPath>..\packages\UmbracoCms.Core.6.2.5\lib\umbraco.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\umbraco.dll</HintPath>
     </Reference>
     <Reference Include="Umbraco.Core">
-      <HintPath>..\packages\UmbracoCms.Core.6.2.5\lib\Umbraco.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\UmbracoCms.Core.7.1.4\lib\Umbraco.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -96,6 +92,10 @@
     <Compile Include="EventArgs\ConvertedTypeEventArgs.cs" />
     <Compile Include="Extensions\RenderModelExtensions.cs" />
     <Compile Include="Extensions\PublishedContentExtensions.cs" />
+    <Compile Include="Models\Archetype\Abstract\ArchetypeModel.cs" />
+    <Compile Include="Models\Archetype\ArchetypeCMSModel.cs" />
+    <Compile Include="Models\Archetype\FieldsetModel.cs" />
+    <Compile Include="Models\Archetype\PropertyModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
   </ItemGroup>

--- a/src/packages/repositories.config
+++ b/src/packages/repositories.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
   <repository path="..\Our.Umbraco.Ditto.ModelFactory\packages.config" />
+  <repository path="..\Our.Umbraco.Ditto.Tests\packages.config" />
   <repository path="..\Our.Umbraco.Ditto\packages.config" />
 </repositories>


### PR DESCRIPTION
Adds support for archetype via the existing UmbracoPropertyAttributeClass which now contains an isArchetype field.

This hooks in to the existing TypeConverters and flow of application. Archetypes POCOs should follow the same naming convention standards as the main ditto POCOs, though will inherit from a base class of ArchetypeModel instead of the IPublishedContent.

I have ran this against almost all of the existing data types and conversion seems OK, though as archetype values are strings one or two data types may have slipped through.