### PR TITLE
Implement new build naming & numbering

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,17 @@
 # version format
 version: 0.7.0.{build}
 
-# UMBRACO_PACKAGE_PRERELEASE_SUFFIX will only be used for Release builds
+# UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta
-install:
-  - cmd: set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=
-  - cmd: build-appveyor.cmd
+init:
+  - set UMBRACO_PACKAGE_PRERELEASE_SUFFIX=
+
+build_script:
+- build-appveyor.cmd
 
 test:
   assemblies:
     - 'Our.Umbraco.Ditto.Tests.dll'
-
-# to disable automatic builds
-build: off
 
 artifacts:
   - path: artifacts\*.nupkg

--- a/build/package.proj
+++ b/build/package.proj
@@ -44,15 +44,28 @@
 	<Choose>
 		<When Condition="$(APPVEYOR_BUILD_NUMBER) != '' And $(APPVEYOR_REPO_TAG) != 'true' ">
 			<PropertyGroup>
-				<VersionSuffix>build$(APPVEYOR_BUILD_NUMBER)</VersionSuffix>
+        <Release>false</Release>
 			</PropertyGroup>
 		</When>
 		<Otherwise>
 			<PropertyGroup>
-				<VersionSuffix>$(UMBRACO_PACKAGE_PRERELEASE_SUFFIX)</VersionSuffix>
+        <Release>true</Release>
 			</PropertyGroup>
 		</Otherwise>
 	</Choose>
+
+  <Choose>
+    <When Condition="$(Release) == 'false' And $(UMBRACO_PACKAGE_PRERELEASE_SUFFIX) == 'rtm'">
+      <PropertyGroup>
+        <AbortBuild>true</AbortBuild>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <AbortBuild>false</AbortBuild>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
 	<!-- PATHS -->
 	<PropertyGroup>
@@ -66,7 +79,8 @@
 
 	<!-- TARGETS -->
 	<Target Name="GetProductVersion">
-		<GetProductVersion BuildVersion="$(APPVEYOR_BUILD_VERSION)" BuildSuffix="$(VersionSuffix)">
+    <Error Condition="$(AbortBuild) == 'true'" Text="Aborting the build as the UMBRACO_PACKAGE_PRERELEASE_SUFFIX suffix is set 'rtm' but APPVEYOR_REPO_TAG is not 'true'" />
+    <GetProductVersion BuildVersion="$(APPVEYOR_BUILD_VERSION)" BuildSuffix="$(UMBRACO_PACKAGE_PRERELEASE_SUFFIX)" Release="$(Release)">
 			<Output TaskParameter="ProductVersion" PropertyName="ProductVersion"/>
 		</GetProductVersion>
 	</Target>

--- a/build/tools/AppVeyorUmbraco/AppVeyorUmbraco.Targets
+++ b/build/tools/AppVeyorUmbraco/AppVeyorUmbraco.Targets
@@ -17,8 +17,7 @@
             var pos = BuildVersion.LastIndexOf('.');
             var len = BuildVersion.Length - pos - 1;
             
-            var buildNumber = ("00000" + BuildVersion.Substring(pos + 1, len));
-            var buildNumberWithZeros = buildNumber.Substring(buildNumber.Length - 6);
+            var buildNumberWithZeros = BuildVersion.Substring(pos + 1, len).PadLeft(6, '0');
 
             var baseVersion = BuildVersion.Substring(0, pos);
 

--- a/build/tools/AppVeyorUmbraco/AppVeyorUmbraco.Targets
+++ b/build/tools/AppVeyorUmbraco/AppVeyorUmbraco.Targets
@@ -4,21 +4,44 @@
     TaskFactory="CodeTaskFactory"
     AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
 	<ParameterGroup>
-      <BuildVersion ParameterType="System.String" Required="true" />
+    <BuildVersion ParameterType="System.String" Required="true" />
 	  <BuildSuffix ParameterType="System.String" Required="false" />
 	  <ProductVersion ParameterType="System.String" Output="true" />
+  	<Release ParameterType="System.String" Required="true" />
 	</ParameterGroup>	
     <Task>
       <Using Namespace="System"/>
       <Using Namespace="System.IO"/>
       <Code Type="Fragment" Language="cs">
 <![CDATA[
-            var baseVersion = BuildVersion.Substring(0, BuildVersion.LastIndexOf('.'));
-            if (string.IsNullOrEmpty(BuildSuffix)){
-			        ProductVersion = baseVersion;
-            } else {
-              ProductVersion = baseVersion + "-" + BuildSuffix;
+            var pos = BuildVersion.LastIndexOf('.');
+            var len = BuildVersion.Length - pos - 1;
+            
+            var buildNumber = ("00000" + BuildVersion.Substring(pos + 1, len));
+            var buildNumberWithZeros = buildNumber.Substring(buildNumber.Length - 6);
+
+            var baseVersion = BuildVersion.Substring(0, pos);
+
+            if ((string.IsNullOrEmpty(BuildSuffix) || BuildSuffix == "rtm") && Release == "true")
+            {
+                ProductVersion = baseVersion;
             }
+            else if (string.IsNullOrEmpty(BuildSuffix) && Release == "false")
+            {
+                ProductVersion = baseVersion + "-alpha-" + buildNumberWithZeros;
+            }
+            else if (!string.IsNullOrEmpty(BuildSuffix) && Release == "true")
+            {
+                ProductVersion = baseVersion + "-" + BuildSuffix;
+            }
+            else if (!string.IsNullOrEmpty(BuildSuffix) && BuildSuffix != "rtm" && Release == "false")
+            {
+                ProductVersion = baseVersion + "-" + BuildSuffix + "-" + buildNumberWithZeros;
+            }
+            else
+            {
+                ProductVersion = "";
+            }          
 //Log.LogError(OutputVer);
 ]]>
       </Code>


### PR DESCRIPTION
Six digit leading zero build numbers

Build numbers suffixed with a hyphen, e.g. "0.7.0-alpha-000022"

CI builds always have a suffix, by default "alpha" but could also be "beta"

If using "beta" CI build and then want to move to RTM, can now use special "rtm" suffix, set UMBRACO_PACKAGE_PRERELEASE_SUFFIX = rtm, when you release via lightweight tag, one build will be the release and will be successful, the other will intentionally fail to avoid a invalid CI build.

This allows this full release pattern if you want it:

	version: 0.7.0.{build}
	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=

		CI > 0.7.0-alpha-0012
		CI > 0.7.0-alpha-0013

	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=alpha
	APPVEYOR_REPO_TAG=true

		Release > 0.7.0-alpha

	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta

		CI > 0.7.0-beta-0015

	APPVEYOR_REPO_TAG=true

		Release > 0.7.0-beta

	UMBRACO_PACKAGE_PRERELEASE_SUFFIX=rtm
	APPVEYOR_REPO_TAG=true
	(this is where a CI build would normally be created as well as the release, it would be 0.7.0-alpha-0017, but instead it will be aborted)

		Release > 0.7.0

Currently Ditto has only CI builds and releases so nothing needs to be changed.

When switching to this new numbering I would recommend that any existing MyGet packages for v0.7.0 are deleted from the feed so that the order starts to work in Visual Studio.