### PR TITLE
Update type converters to treat emtpy string the same as null

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConverterHelper.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConverterHelper.cs
@@ -84,5 +84,16 @@
 
             return ids.ToArray();
         }
+
+
+        /// <summary>
+        /// Gets a value indicating if the object is null or the empty string
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>true if the value is null or string.Empty</returns>
+        public static bool IsNullOrEmptyString(object value)
+        {
+            return value == null || value as string == "";
+        }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/ContentPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/ContentPickerConverter.cs
@@ -48,7 +48,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 return null;
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/EnumConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/EnumConverter.cs
@@ -59,7 +59,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 return default(TEnum);
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MediaPickerConverter.cs
@@ -50,7 +50,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 return null;
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MemberPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MemberPickerConverter.cs
@@ -48,7 +48,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 return null;
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultiNodeTreePickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultiNodeTreePickerConverter.cs
@@ -55,7 +55,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 return Enumerable.Empty<T>();
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultipleMediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/MultipleMediaPickerConverter.cs
@@ -50,7 +50,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 return Enumerable.Empty<T>();
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/UltimatePickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/UltimatePickerConverter.cs
@@ -48,7 +48,7 @@
         /// </returns>
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            if (value == null)
+            if (ConverterHelper.IsNullOrEmptyString(value))
             {
                 if (typeof(T).IsEnumerableType())
                 {


### PR DESCRIPTION
Empty strings pass through to the base TypeConverter and for enumerable
types at least, this results in a NotSupportedException.

cc90af9 added support for accepting null values, and in pretty much
every case, empty string should be treated as null: no meaninful data
can be gleaned from it for conversion.

EnumConverter works without the check because the empty string gets
pased to the base ConvertFrom method which just returns the default enum
value. But we might as well be explicit about the expected return result
for empty strings.

Fixes #58