### PR TITLE
Looking at option to make cleaner value resolvers

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/AppSettingValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/AppSettingValueResolver.cs
@@ -12,20 +12,12 @@
         /// <summary>
         /// Gets the value from the web.config app setting
         /// </summary>
-        /// <param name="context">
-        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
-        /// </param>
-        /// <param name="attribute">
-        /// The <see cref="AppSettingAttribute"/> containing additional information 
-        /// indicating how to resolve the property.
-        /// </param>
-        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
         /// <returns>
         /// The <see cref="object"/> representing the raw value.
         /// </returns>
-        public override object ResolveValue(ITypeDescriptorContext context, AppSettingAttribute attribute, CultureInfo culture)
+        public override object ResolveValue()
         {
-            var appSettingKey = attribute.AppSettingKey ?? (context.PropertyDescriptor != null ? context.PropertyDescriptor.Name : string.Empty);
+            var appSettingKey = Attribute.AppSettingKey ?? (Context.PropertyDescriptor != null ? Context.PropertyDescriptor.Name : string.Empty);
 
             if (string.IsNullOrWhiteSpace(appSettingKey))
             {

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/CurrentContentAsValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/CurrentContentAsValueResolver.cs
@@ -1,8 +1,6 @@
 ﻿namespace Our.Umbraco.Ditto
 {
     using System;
-    using System.ComponentModel;
-    using System.Globalization;
 
     using global::Umbraco.Core.Models;
 
@@ -15,29 +13,21 @@
         /// Resolves the value.
         /// Gets the current <see cref="IPublishedContent"/> from Umbraco.
         /// </summary>
-        /// <param name="context">
-        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
-        /// </param>
-        /// <param name="attribute">
-        /// The <see cref="CurrentContentAsAttribute"/> containing additional information 
-        /// indicating how to resolve the property.
-        /// </param>
-        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
         /// <returns>
         /// The <see cref="object"/> representing the raw value.
         /// </returns>
-        public override object ResolveValue(ITypeDescriptorContext context, CurrentContentAsAttribute attribute, CultureInfo culture)
+        public override object ResolveValue()
         {
             // NOTE: [LK] In order to prevent an infinite loop / stack-overflow, we check if the
             // property's type matches the containing model's type, then we throw an exception.
-            if (context.PropertyDescriptor.PropertyType == context.PropertyDescriptor.ComponentType)
+            if (Context.PropertyDescriptor.PropertyType == Context.PropertyDescriptor.ComponentType)
             {
                 throw new InvalidOperationException(
                     string.Format("Unable to process property type '{0}', it is the same as the containing model type.",
-                    context.PropertyDescriptor.PropertyType.Name));
+                    Context.PropertyDescriptor.PropertyType.Name));
             }
 
-            return ((IPublishedContent)context.Instance).As(context.PropertyDescriptor.PropertyType);
+            return Content.As(Context.PropertyDescriptor.PropertyType);
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolver.cs
@@ -1,4 +1,7 @@
-﻿namespace Our.Umbraco.Ditto
+﻿using Umbraco.Core.Models;
+using Umbraco.Web.PublishedCache;
+
+namespace Our.Umbraco.Ditto
 {
     using System;
     using System.ComponentModel;
@@ -10,6 +13,26 @@
     /// </summary>
     public abstract class DittoValueResolver
     {
+        /// <summary>
+        /// Gets or sets the resovler context.
+        /// </summary>
+        public ITypeDescriptorContext Context { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the IPublishedContent object.
+        /// </summary>
+        public IPublishedContent Content { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the associated attribute.
+        /// </summary>
+        public DittoValueResolverAttribute Attribute { get; protected set; }
+
+        /// <summary>
+        /// Gets or sets the culture object.
+        /// </summary>
+        public CultureInfo Culture { get; protected set; } 
+
         /// <summary>
         /// Gets the raw value for the current property from Umbraco.
         /// </summary>
@@ -24,7 +47,24 @@
         /// <returns>
         /// The <see cref="object"/> representing the raw value.
         /// </returns>
-        public abstract object ResolveValue(ITypeDescriptorContext context, DittoValueResolverAttribute attribute, CultureInfo culture);
+        public virtual object ResolveValue(ITypeDescriptorContext context, DittoValueResolverAttribute attribute,
+            CultureInfo culture)
+        {
+            Context = context;
+            Content = context.Instance as IPublishedContent;
+            Attribute = attribute;
+            Culture = culture;
+
+            return ResolveValue();
+        }
+
+        /// <summary>
+        /// Performs the value resolution.
+        /// </summary>
+        /// /// <returns>
+        /// The <see cref="object"/> representing the raw value.
+        /// </returns>
+        public abstract object ResolveValue();
     }
 
     /// <summary>
@@ -38,6 +78,11 @@
     public abstract class DittoValueResolver<TAttributeType> : DittoValueResolver
         where TAttributeType : DittoValueResolverAttribute
     {
+        /// <summary>
+        /// Gets or sets the associated attribute.
+        /// </summary>
+        public new TAttributeType Attribute { get; protected set; }
+
         /// <summary>
         /// Gets the raw value for the current property from Umbraco.
         /// </summary>
@@ -61,23 +106,12 @@
                     "attribute");
             }
 
-            return this.ResolveValue(context, (TAttributeType)attribute, culture);
-        }
+            Context = context;
+            Content = context.Instance as IPublishedContent;
+            Attribute = attribute as TAttributeType;
+            Culture = culture;
 
-        /// <summary>
-        /// Gets the raw value for the current property from Umbraco.
-        /// </summary>
-        /// <param name="context">
-        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
-        /// </param>
-        /// <param name="attribute">
-        /// The <see cref="TAttributeType"/> containing additional information 
-        /// indicating how to resolve the property.
-        /// </param>
-        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
-        /// <returns>
-        /// The <see cref="object"/> representing the raw value.
-        /// </returns>
-        public abstract object ResolveValue(ITypeDescriptorContext context, TAttributeType attribute, CultureInfo culture);
+            return ResolveValue();
+        }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoDictionaryValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoDictionaryValueResolver.cs
@@ -1,9 +1,5 @@
 ﻿namespace Our.Umbraco.Ditto
 {
-    using System.ComponentModel;
-    using System.Globalization;
-
-    using global::Umbraco.Core.Models;
     using global::Umbraco.Web;
 
     /// <summary>
@@ -14,30 +10,20 @@
         /// <summary>
         /// Gets the raw value for the current property from Umbraco.
         /// </summary>
-        /// <param name="context">
-        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
-        /// </param>
-        /// <param name="attribute">
-        /// The <see cref="UmbracoDictionaryAttribute"/> containing additional information 
-        /// indicating how to resolve the property.
-        /// </param>
-        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
         /// <returns>
         /// The <see cref="object"/> representing the raw value.
         /// </returns>
-        public override object ResolveValue(ITypeDescriptorContext context, UmbracoDictionaryAttribute attribute, CultureInfo culture)
+        public override object ResolveValue()
         {
-            var dictionaryKey = attribute.DictionaryKey ?? (context.PropertyDescriptor != null ? context.PropertyDescriptor.Name : string.Empty);
+            var dictionaryKey = Attribute.DictionaryKey ?? (Context.PropertyDescriptor != null ? Context.PropertyDescriptor.Name : string.Empty);
 
             if (string.IsNullOrWhiteSpace(dictionaryKey))
             {
                 return null;
             }
 
-            var content = context.Instance as IPublishedContent;
-
             // HACK: [LK:2015-04-14] Resorting to using `UmbracoHelper`, as `CultureDictionaryFactoryResolver` isn't public in v6.2.x.
-            return new UmbracoHelper(UmbracoContext.Current, content).GetDictionaryValue(dictionaryKey);
+            return new UmbracoHelper(UmbracoContext.Current, Content).GetDictionaryValue(dictionaryKey);
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoPropertyValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoPropertyValueResolver.cs
@@ -2,9 +2,6 @@
 
 namespace Our.Umbraco.Ditto
 {
-    using System.ComponentModel;
-    using System.Globalization;
-
     using global::Umbraco.Core;
     using global::Umbraco.Core.Models;
     using global::Umbraco.Web;
@@ -17,29 +14,21 @@ namespace Our.Umbraco.Ditto
         /// <summary>
         /// Gets the raw value for the current property from Umbraco.
         /// </summary>
-        /// <param name="context">
-        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
-        /// </param>
-        /// <param name="attribute">
-        /// The <see cref="UmbracoPropertyAttribute"/> containing additional information 
-        /// indicating how to resolve the property.
-        /// </param>
-        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
         /// <returns>
         /// The <see cref="object"/> representing the raw value.
         /// </returns>
-        public override object ResolveValue(ITypeDescriptorContext context, UmbracoPropertyAttribute attribute, CultureInfo culture)
+        public override object ResolveValue()
         {
-            var defaultValue = attribute.DefaultValue;
+            var defaultValue = Attribute.DefaultValue;
 
-            var recursive = attribute.Recursive;
-            var propName = context.PropertyDescriptor != null ? context.PropertyDescriptor.Name : string.Empty;
+            var recursive = Attribute.Recursive;
+            var propName = Context.PropertyDescriptor != null ? Context.PropertyDescriptor.Name : string.Empty;
             var altPropName = "";
 
             // Check for umbraco properties attribute on class
-            if (context.PropertyDescriptor != null)
+            if (Context.PropertyDescriptor != null)
             {
-                var classAttr = context.PropertyDescriptor.ComponentType
+                var classAttr = Context.PropertyDescriptor.ComponentType
                     .GetCustomAttribute<UmbracoPropertiesAttribute>();
                 if (classAttr != null)
                 {
@@ -55,10 +44,10 @@ namespace Our.Umbraco.Ditto
                 }
             }
 
-            var umbracoPropertyName = attribute.PropertyName ?? propName;
-            var altUmbracoPropertyName = attribute.AltPropertyName ?? altPropName;
+            var umbracoPropertyName = Attribute.PropertyName ?? propName;
+            var altUmbracoPropertyName = Attribute.AltPropertyName ?? altPropName;
 
-            var content = context.Instance as IPublishedContent;
+            var content = Context.Instance as IPublishedContent;
             if (content == null)
             {
                 return defaultValue;

--- a/tests/Our.Umbraco.Ditto.Tests/MockValueResolverTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/MockValueResolverTests.cs
@@ -24,9 +24,9 @@
 
         public class MockValueResolver : DittoValueResolver<MockValueAttribute>
         {
-            public override object ResolveValue(ITypeDescriptorContext context, MockValueAttribute attribute, CultureInfo culture)
+            public override object ResolveValue()
             {
-                return attribute.RawValue;
+                return Attribute.RawValue;
             }
         }
 

--- a/tests/Our.Umbraco.Ditto.Tests/Models/ComplexModel.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Models/ComplexModel.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace Our.Umbraco.Ditto.Tests.Models
+﻿namespace Our.Umbraco.Ditto.Tests.Models
 {
     using System.ComponentModel;
 
@@ -27,13 +25,9 @@ namespace Our.Umbraco.Ditto.Tests.Models
 
     public class NameValueResovler : DittoValueResolver
     {
-        public override object ResolveValue(ITypeDescriptorContext context, 
-            DittoValueResolverAttribute attribute, CultureInfo culture)
+        public override object ResolveValue()
         {
-            var content = context.Instance as IPublishedContent;
-            if (content == null) return null;
-
-            return content.Name + " Test";
+            return (Content != null) ? Content.Name + " Test" : null;
         }
     }
 }


### PR DESCRIPTION
Currently when you create a value resolver, you have to override a ResolveValue function that has a bunch of params that get passed through, for example: 

![capture1](https://cloud.githubusercontent.com/assets/527305/8207574/56f8543e-14fa-11e5-9d4f-0ee490c2b010.PNG)

What I've done in this pull request is added a bunch of props to the ValueResolver class to hold these params, and simplified the ResolveValue method to a parameterless function

![capture2](https://cloud.githubusercontent.com/assets/527305/8207597/7cd9a4c8-14fa-11e5-9d8b-e59f8fc0186e.PNG)

An added advantage to this is that I've also added a Content property which casts the context.instance property to IPublishedContent as this is going to be a common action.

The only negative in my eyes is that it isn't entirely obvious what properties are available to you, though I think this could be resolved with some documentation. My imediate feeling though is that less code = better.

What do you guys think?