### PR TITLE
Register Global Conversion Handlers

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerRegistry.cs
@@ -12,19 +12,17 @@ namespace Our.Umbraco.Ditto
         /// <summary>
         /// The cache for storing handler information.
         /// </summary>
-        private static readonly Dictionary<Type, IList<Type>> HandlerCache
-            = new  Dictionary<Type, IList<Type>>();
+        private static readonly Dictionary<Type, IList<Type>> Cache = new  Dictionary<Type, IList<Type>>();
 
         /// <summary>
-        /// The lock object to make HandlerCache access thread safe
+        /// The lock object to make Cache access thread safe
         /// </summary>
         private static object _cacheLock = new object();
 
         /// <summary>
         /// Static holder for singleton instance.
         /// </summary>
-        private static readonly Lazy<DittoConversionHandlerRegistry> _instance
-            = new Lazy<DittoConversionHandlerRegistry>(() => new DittoConversionHandlerRegistry());
+        private static readonly Lazy<DittoConversionHandlerRegistry> _instance = new Lazy<DittoConversionHandlerRegistry>(() => new DittoConversionHandlerRegistry());
 
         /// <summary>
         /// Private constructor to prevent direct instantiation..
@@ -59,16 +57,16 @@ namespace Our.Umbraco.Ditto
 
             lock (_cacheLock)
             {
-                if (HandlerCache.ContainsKey(objType))
+                if (Cache.ContainsKey(objType))
                 {
-                    if (!HandlerCache[objType].Contains(handlerType))
+                    if (!Cache[objType].Contains(handlerType))
                     {
-                        HandlerCache[objType].Add(handlerType);
+                        Cache[objType].Add(handlerType);
                     }
                 }
                 else
                 {
-                    HandlerCache.Add(objType, new [] { handlerType });
+                    Cache.Add(objType, new [] { handlerType });
                 }
             }
         }
@@ -82,8 +80,8 @@ namespace Our.Umbraco.Ditto
         {
             lock (_cacheLock)
             {
-                return HandlerCache.ContainsKey(objectType)
-                    ? HandlerCache[objectType].ToList()
+                return Cache.ContainsKey(objectType)
+                    ? Cache[objectType].ToList()
                     : Enumerable.Empty<Type>();
             }
         }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerRegistry.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// Registory for globaly registered conversion handlers.
+    /// </summary>
+    internal class DittoConversionHandlerRegistry
+    {
+        /// <summary>
+        /// The cache for storing handler information.
+        /// </summary>
+        private static readonly Dictionary<Type, IList<Type>> HandlerCache
+            = new  Dictionary<Type, IList<Type>>();
+
+        /// <summary>
+        /// The lock object to make HandlerCache access thread safe
+        /// </summary>
+        private static object _cacheLock = new object();
+
+        /// <summary>
+        /// Static holder for singleton instance.
+        /// </summary>
+        private static readonly Lazy<DittoConversionHandlerRegistry> _instance
+            = new Lazy<DittoConversionHandlerRegistry>(() => new DittoConversionHandlerRegistry());
+
+        /// <summary>
+        /// Private constructor to prevent direct instantiation..
+        /// </summary>
+        private DittoConversionHandlerRegistry()
+        { }
+
+        /// <summary>
+        /// Gets the singleton instance.
+        /// </summary>
+        /// <value>
+        /// The instance.
+        /// </value>
+        public static DittoConversionHandlerRegistry Instance
+        {
+            get
+            {
+                return _instance.Value;
+            }
+        }
+
+        /// <summary>
+        /// Registers a global conversion handler.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="THandlerType">The type of the handler.</typeparam>
+        public void RegisterHandler<TObjectType, THandlerType>()
+            where THandlerType : DittoConversionHandler
+        {
+            var objType = typeof(TObjectType);
+            var handlerType = typeof(THandlerType);
+
+            lock (_cacheLock)
+            {
+                if (HandlerCache.ContainsKey(objType))
+                {
+                    if (!HandlerCache[objType].Contains(handlerType))
+                    {
+                        HandlerCache[objType].Add(handlerType);
+                    }
+                }
+                else
+                {
+                    HandlerCache.Add(objType, new [] { handlerType });
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the registered handler types for the given object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns></returns>
+        public IEnumerable<Type> GetRegisteredHandlerTypesFor(Type objectType)
+        {
+            lock (_cacheLock)
+            {
+                return HandlerCache.ContainsKey(objectType)
+                    ? HandlerCache[objectType].ToList()
+                    : Enumerable.Empty<Type>();
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolver.cs
@@ -13,25 +13,6 @@
     /// </summary>
     public abstract class DittoValueResolver
     {
-        //private const string CONTEXT_KEY_FORMAT = "Ditto_ValueResolverContext_{0}";
-
-        ///// <summary>
-        ///// Gets the value resolver context cache container.
-        ///// </summary>
-        //private static IDictionary _contextCache;
-        //private static IDictionary ContextCache
-        //{
-        //    get
-        //    {
-        //        if (_contextCache != null)
-        //            return _contextCache;
-
-        //        return HttpContext.Current != null
-        //            ? HttpContext.Current.Items
-        //            : null;
-        //    }
-        //}
-
         /// <summary>
         /// Gets or sets the IPublishedContent object.
         /// </summary>
@@ -84,56 +65,6 @@
         /// The <see cref="object"/> representing the raw value.
         /// </returns>
         public abstract object ResolveValue();
-
-        /// <summary>
-        /// Registers a value resolver context for the current request.
-        /// </summary>
-        /// <param name="ctx">
-        /// The <see cref="DittoValueResolverContext" /> to register.
-        /// </param>
-        //internal static void RegisterContext<TContextType>(TContextType ctx)
-        //    where TContextType : DittoValueResolverContext
-        //{
-        //    var key = string.Format(CONTEXT_KEY_FORMAT, typeof(TContextType).FullName);
-
-        //    if (ContextCache != null)
-        //    {
-        //        if (ContextCache.Contains(key))
-        //        {
-        //            ContextCache[key] = ctx;
-        //        }
-        //        else
-        //        {
-        //            ContextCache.Add(key, ctx);
-        //        }
-        //    }
-        //}
-
-        /// <summary>
-        /// Retreieves a value resolver context of the given type if one exists.
-        /// </summary>
-        /// <param name="contextType">
-        /// The <see cref="DittoValueResolverContext" /> type to lookup.
-        /// </param>
-        /// <returns>
-        /// The registered <see cref="DittoValueResolverContext"/> instance.
-        /// </returns>
-        //internal static DittoValueResolverContext GetRegistedContext(Type contextType)
-        //{
-        //    var key = string.Format(CONTEXT_KEY_FORMAT, contextType.FullName);
-
-        //    return ContextCache != null && ContextCache.Contains(key)
-        //        ? (DittoValueResolverContext)ContextCache[key]
-        //        : null;
-        //}
-
-        /// <summary>
-        /// Helper function to allow setting the context cache container manually, should only be used for testing.
-        /// </summary>
-        //internal static void SetContextCache(IDictionary cache)
-        //{
-        //    _contextCache = cache;
-        //}
     }
 
     /// <summary>

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolverRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolverRegistry.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// Registory for globaly registered value resovlers.
+    /// </summary>
+    internal class DittoValueResolverRegistry
+    {
+        /// <summary>
+        /// The cache for storing handler information.
+        /// </summary>
+        private static readonly Dictionary<Type, DittoValueResolverAttribute> Cache = new Dictionary<Type, DittoValueResolverAttribute>();
+
+        /// <summary>
+        /// The lock object to make Cache access thread safe
+        /// </summary>
+        private static object _cacheLock = new object();
+
+        /// <summary>
+        /// Static holder for singleton instance.
+        /// </summary>
+        private static readonly Lazy<DittoValueResolverRegistry> _instance = new Lazy<DittoValueResolverRegistry>(() => new DittoValueResolverRegistry());
+
+        /// <summary>
+        /// Private constructor to prevent direct instantiation..
+        /// </summary>
+        private DittoValueResolverRegistry()
+        { }
+
+        /// <summary>
+        /// Gets the singleton instance.
+        /// </summary>
+        /// <value>
+        /// The instance.
+        /// </value>
+        public static DittoValueResolverRegistry Instance
+        {
+            get
+            {
+                return _instance.Value;
+            }
+        }
+
+        /// <summary>
+        /// Registers a global value resolver.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="TResolverType">The type of the value resolver.</typeparam>
+        public void RegisterResolver<TObjectType, TResolverType>()
+            where TResolverType : DittoValueResolver
+        {
+            RegisterResolverAttribute<TObjectType, DittoValueResolverAttribute>(new DittoValueResolverAttribute(typeof(TResolverType)));
+        }
+
+        /// <summary>
+        /// Registers a global value resolver attribute.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="TResolverAttributeType">The type of the value resolver attribute.</typeparam>
+        public void RegisterResolverAttribute<TObjectType, TResolverAttributeType>()
+            where TResolverAttributeType : DittoValueResolverAttribute, new()
+        {
+            RegisterResolverAttribute<TObjectType, TResolverAttributeType>((TResolverAttributeType)typeof(TResolverAttributeType).GetInstance());
+        }
+
+        /// <summary>
+        /// Registers a global value resolver attribute.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object type.</typeparam>
+        /// <typeparam name="TResolverAttributeType">The type of the resolver attribute type.</typeparam>
+        /// <param name="instance">An instance of the value resolver attibute type to use.</param>
+        public void RegisterResolverAttribute<TObjectType, TResolverAttributeType>(TResolverAttributeType instance)
+            where TResolverAttributeType : DittoValueResolverAttribute
+        {
+            var objType = typeof(TObjectType);
+
+            lock (_cacheLock)
+            {
+                if (Cache.ContainsKey(objType))
+                {
+                    Cache[objType] = instance;
+                }
+                else
+                {
+                    Cache.Add(objType, instance);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the registered value resolver attribute for the given object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns></returns>
+        public DittoValueResolverAttribute GetRegisteredResolverAttributeFor(Type objectType)
+        {
+            lock (_cacheLock)
+            {
+                return Cache.ContainsKey(objectType)
+                    ? Cache[objectType]
+                    : null;
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -1,4 +1,6 @@
-﻿namespace Our.Umbraco.Ditto
+﻿using System.ComponentModel;
+
+namespace Our.Umbraco.Ditto
 {
     /// <summary>
     /// The public facade for non extension method Ditto actions
@@ -14,6 +16,51 @@
             where THandlerType : DittoConversionHandler
         {
             DittoConversionHandlerRegistry.Instance.RegisterHandler<TObjectType, THandlerType>();
+        }
+
+        /// <summary>
+        /// Registers a global value resolver.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="TResolverType">The type of the value resolver.</typeparam>
+        public static void RegisterValueResolver<TObjectType, TResolverType>()
+            where TResolverType : DittoValueResolver
+        {
+            DittoValueResolverRegistry.Instance.RegisterResolver<TObjectType, TResolverType>();
+        }
+
+        /// <summary>
+        /// Registers a global value resolver attribute.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="TResolverAttributeType">The type of the value resolver attribute.</typeparam>
+        public static void RegisterValueResolverAttribute<TObjectType, TResolverAttributeType>()
+            where TResolverAttributeType : DittoValueResolverAttribute, new()
+        {
+            DittoValueResolverRegistry.Instance.RegisterResolverAttribute<TObjectType, TResolverAttributeType>();
+        }
+
+        /// <summary>
+        /// Registers a global value resolver attribute.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="TResolverAttributeType">The type of the value resolver attribute.</typeparam>
+        /// <param name="instance">An instance of the value resolver attribute to use.</param>
+        public static void RegisterValueResolverAttribute<TObjectType, TResolverAttributeType>(TResolverAttributeType instance)
+            where TResolverAttributeType : DittoValueResolverAttribute
+        {
+            DittoValueResolverRegistry.Instance.RegisterResolverAttribute<TObjectType, TResolverAttributeType>(instance);
+        }
+
+        /// <summary>
+        /// Registers a global type converter.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="TConverterType">The type of the converter.</typeparam>
+        public static void RegisterTypeConverter<TObjectType, TConverterType>()
+            where TConverterType : TypeConverter
+        {
+            TypeDescriptor.AddAttributes(typeof(TObjectType), new TypeConverterAttribute(typeof(TConverterType)));
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -5,10 +5,15 @@
     /// </summary>
     public class Ditto
     {
-        //public static void RegisterValueResolverContext<TContextType>(TContextType ctx)
-        //    where TContextType : DittoValueResolverContext
-        //{
-        //    DittoValueResolver.RegisterContext(ctx);
-        //}
+        /// <summary>
+        /// Registers a global conversion handler.
+        /// </summary>
+        /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>
+        /// <typeparam name="THandlerType">The type of the handler.</typeparam>
+        public static void RegisterConversionHandler<TObjectType, THandlerType>()
+            where THandlerType : DittoConversionHandler
+        {
+            DittoConversionHandlerRegistry.Instance.RegisterHandler<TObjectType, THandlerType>();
+        }
     }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -662,6 +662,12 @@
                 ((DittoConversionHandler)attr.HandlerType.GetInstance(conversionCtx)).OnConverting();
             }
 
+            // Check for globaly registered handlers
+            foreach (var handlerType in DittoConversionHandlerRegistry.Instance.GetRegisteredHandlerTypesFor(type))
+            {
+                ((DittoConversionHandler)handlerType.GetInstance(conversionCtx)).OnConverting();
+            }
+
             // Check for method level DittoOnConvertedAttributes
             foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(x => x.GetCustomAttribute<DittoOnConvertingAttribute>() != null))
@@ -707,6 +713,12 @@
             foreach (var attr in type.GetCustomAttributes<DittoConversionHandlerAttribute>())
             {
                 ((DittoConversionHandler)attr.HandlerType.GetInstance(conversionCtx)).OnConverted();
+            }
+
+            // Check for globaly registered handlers
+            foreach (var handlerType in DittoConversionHandlerRegistry.Instance.GetRegisteredHandlerTypesFor(type))
+            {
+                ((DittoConversionHandler)handlerType.GetInstance(conversionCtx)).OnConverted();
             }
 
             // Check for method level DittoOnConvertedAttributes

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -400,8 +400,19 @@
             IEnumerable<DittoValueResolverContext> valueResolverContexts = null)
         {
             // Check the property for an associated value attribute, otherwise fall-back on expected behaviour.
-            var valueAttr = propertyInfo.GetCustomAttribute<DittoValueResolverAttribute>(true)
-                ?? new UmbracoPropertyAttribute();
+            var valueAttr = propertyInfo.GetCustomAttribute<DittoValueResolverAttribute>(true);
+
+            if (valueAttr == null)
+            {
+                // Check for globally registerd resolver
+                valueAttr = DittoValueResolverRegistry.Instance.GetRegisteredResolverAttributeFor(propertyInfo.PropertyType);
+            }
+
+            if (valueAttr == null)
+            {
+                // Default to umbraco property attribute
+                valueAttr = new UmbracoPropertyAttribute();
+            }
 
             // Time custom value-resolver.
             using (DisposableTimer.DebugDuration<object>(string.Format("Custom ValueResolver ({0}, {1})", content.Id, propertyInfo.Name), "Complete"))

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Attributes\UmbracoPropertyAttribute.cs" />
     <Compile Include="Common\EnumerableInvocations.cs" />
     <Compile Include="Common\MethodBaseCacheItem.cs" />
+    <Compile Include="ComponentModel\ConversionHandlers\DittoConversionHandlerRegistry.cs" />
     <Compile Include="ComponentModel\DittoConversionHandlerContext.cs" />
     <Compile Include="ComponentModel\ConversionHandlers\DittoConversionHandler.cs" />
     <Compile Include="ComponentModel\PublishedContentContext.cs" />

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -107,6 +107,7 @@
     <Compile Include="ComponentModel\TypeConverters\DittoHtmlStringConverter.cs" />
     <Compile Include="ComponentModel\ValueResolvers\AppSettingValueResolver.cs" />
     <Compile Include="ComponentModel\ValueResolvers\CurrentContentAsValueResolver.cs" />
+    <Compile Include="ComponentModel\ValueResolvers\DittoValueResolverRegistry.cs" />
     <Compile Include="ComponentModel\ValueResolvers\DittoValueResolver.cs" />
     <Compile Include="ComponentModel\ValueResolvers\DittoValueResolverContext.cs" />
     <Compile Include="ComponentModel\ValueResolvers\UmbracoDictionaryValueResolver.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/ConversionHandlerTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ConversionHandlerTests.cs
@@ -1,0 +1,65 @@
+﻿using NUnit.Framework;
+
+using Our.Umbraco.Ditto.Tests.Mocks;
+using Our.Umbraco.Ditto.Tests.Models;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    public class ConversionHandlerTests
+    {
+        [Test]
+        public void Can_Run_Conversion_Handlers()
+        {
+            var content = new PublishedContentMock
+            {
+                Properties = new[]
+                {
+                    new PublishedContentPropertyMock
+                    {
+                        Alias = "prop1",
+                        Value = "Test1"
+                    },
+                    new PublishedContentPropertyMock
+                    {
+                        Alias = "prop2",
+                        Value = "Test2"
+                    }
+                }
+            };
+
+            var model = content.As<CalculatedModel>();
+
+            Assert.That(model.AltText, Is.EqualTo("Test1 Test2"));
+            Assert.That(model.Name, Is.EqualTo("Test"));
+            Assert.That(model.AltText2, Is.EqualTo("Test1 Test2"));
+        }
+
+        [Test]
+        public void Can_Run_Global_Conversion_Handlers()
+        {
+            var content = new PublishedContentMock
+            {
+                Properties = new[]
+                {
+                    new PublishedContentPropertyMock
+                    {
+                        Alias = "prop1",
+                        Value = "Test1"
+                    },
+                    new PublishedContentPropertyMock
+                    {
+                        Alias = "prop2",
+                        Value = "Test2"
+                    }
+                }
+            };
+
+            Ditto.RegisterConversionHandler<CalculatedModel2, CalculatedModel2ConversionHandler>();
+
+            var model = content.As<CalculatedModel2>();
+
+            Assert.That(model.AltText2, Is.EqualTo("Test1 Test2"));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/GlobalValueResolverTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/GlobalValueResolverTests.cs
@@ -14,9 +14,19 @@ namespace Our.Umbraco.Ditto.Tests
     {
         public class MyValueResolverModel
         {
-            public string MyStrProperty { get; set; }
+            public MyStringModel MyStrProperty { get; set; }
 
-            public int MyIntProperty { get; set; }
+            public MyIntModel MyIntProperty { get; set; }
+        }
+
+        public class MyStringModel
+        {
+            public string Value { get; set; }
+        }
+
+        public class MyIntModel
+        {
+            public int Value { get; set; }
         }
 
         public class MyIntValueResolverAttr : DittoValueResolverAttribute
@@ -32,7 +42,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override object ResolveValue()
             {
-                return Attribute.AttrProp;
+                return new MyIntModel { Value = Attribute.AttrProp }; ;
             }
         }
 
@@ -40,22 +50,22 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override object ResolveValue()
             {
-                return "Test";
+                return new MyStringModel { Value = "Test" };
             }
         }
 
         [Test]
         public void Global_Value_Converter_Resolves()
         {
-            Ditto.RegisterValueResolver<string, MyStrValueResolver>();
-            Ditto.RegisterValueResolverAttribute<int, MyIntValueResolverAttr>(new MyIntValueResolverAttr { AttrProp = 5 });
+            Ditto.RegisterValueResolver<MyStringModel, MyStrValueResolver>();
+            Ditto.RegisterValueResolverAttribute<MyIntModel, MyIntValueResolverAttr>(new MyIntValueResolverAttr { AttrProp = 5 });
 
             var content = new PublishedContentMock();
 
             var model = content.As<MyValueResolverModel>();
 
-            Assert.That(model.MyStrProperty, Is.EqualTo("Test"));
-            Assert.That(model.MyIntProperty, Is.EqualTo(5));
+            Assert.That(model.MyStrProperty.Value, Is.EqualTo("Test"));
+            Assert.That(model.MyIntProperty.Value, Is.EqualTo(5));
         }
     }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/GlobalValueResolverTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/GlobalValueResolverTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Umbraco.Core;
+using Umbraco.Web.Media.EmbedProviders.Settings;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    using NUnit.Framework;
+    using Our.Umbraco.Ditto.Tests.Mocks;
+
+    [TestFixture]
+    public class GlobalValueResolverTests
+    {
+        public class MyValueResolverModel
+        {
+            public string MyStrProperty { get; set; }
+
+            public int MyIntProperty { get; set; }
+        }
+
+        public class MyIntValueResolverAttr : DittoValueResolverAttribute
+        {
+            public MyIntValueResolverAttr()
+                : base(typeof(MyIntValueResolver))
+            { }
+
+            public int AttrProp { get; set; }
+        }
+
+        public class MyIntValueResolver : DittoValueResolver<DittoValueResolverContext, MyIntValueResolverAttr>
+        {
+            public override object ResolveValue()
+            {
+                return Attribute.AttrProp;
+            }
+        }
+
+        public class MyStrValueResolver : DittoValueResolver
+        {
+            public override object ResolveValue()
+            {
+                return "Test";
+            }
+        }
+
+        [Test]
+        public void Global_Value_Converter_Resolves()
+        {
+            Ditto.RegisterValueResolver<string, MyStrValueResolver>();
+            Ditto.RegisterValueResolverAttribute<int, MyIntValueResolverAttr>(new MyIntValueResolverAttr { AttrProp = 5 });
+
+            var content = new PublishedContentMock();
+
+            var model = content.As<MyValueResolverModel>();
+
+            Assert.That(model.MyStrProperty, Is.EqualTo("Test"));
+            Assert.That(model.MyIntProperty, Is.EqualTo(5));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Models/CalculatedModel.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Models/CalculatedModel.cs
@@ -17,6 +17,12 @@
         }
     }
 
+    public class CalculatedModel2 : BaseCalculatedModel
+    {
+        [DittoIgnore]
+        public string AltText2 { get; set; }
+    }
+
     public class BaseCalculatedModel
     {
         [DittoIgnore]
@@ -33,6 +39,19 @@
     public class CalculatedModelConversionHandler : DittoConversionHandler<CalculatedModel>
     {
         public CalculatedModelConversionHandler(DittoConversionHandlerContext ctx) 
+            : base(ctx)
+        { }
+
+        public override void OnConverted()
+        {
+            Model.AltText2 = Content.GetPropertyValue("prop1") + " " +
+                Content.GetPropertyValue("prop2");
+        }
+    }
+
+    public class CalculatedModel2ConversionHandler : DittoConversionHandler<CalculatedModel2>
+    {
+        public CalculatedModel2ConversionHandler(DittoConversionHandlerContext ctx)
             : base(ctx)
         { }
 

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -212,6 +212,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ConversionHandlerTests.cs" />
+    <Compile Include="GlobalValueResolverTests.cs" />
     <Compile Include="ValueResolverContextTests.cs" />
     <Compile Include="CurrentContentTests.cs" />
     <Compile Include="AppSettingsTests.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -211,6 +211,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ConversionHandlerTests.cs" />
     <Compile Include="ValueResolverContextTests.cs" />
     <Compile Include="CurrentContentTests.cs" />
     <Compile Include="AppSettingsTests.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/PublishedContentTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/PublishedContentTests.cs
@@ -297,33 +297,5 @@ namespace Our.Umbraco.Ditto.Tests
             Assert.That(model.ContentListProp.Count(), Is.EqualTo(5));
             Assert.That(model.ContentListProp.All(x => x.InnerProp == "Inner Prop"), Is.EqualTo(true));
         }
-        
-
-        [Test]
-        public void Can_Resolve_Calculated_Properties()
-        {
-            var content = new PublishedContentMock
-            {
-                Properties = new[]
-                {
-                    new PublishedContentPropertyMock
-                    {
-                        Alias = "prop1",
-                        Value = "Test1"
-                    },
-                    new PublishedContentPropertyMock
-                    {
-                        Alias = "prop2",
-                        Value = "Test2"
-                    }
-                }
-            };
-
-            var model = content.As<CalculatedModel>();
-
-            Assert.That(model.AltText, Is.EqualTo("Test1 Test2"));
-            Assert.That(model.Name, Is.EqualTo("Test"));
-            Assert.That(model.AltText2, Is.EqualTo("Test1 Test2"));
-        }
     }
 }


### PR DESCRIPTION
During a discussion with @leekelleher he came up with a scenario that is not currently supported by the new conversion handlers which was previously supported by the events system which was having the ability to modify objects during conversion that are outside our control (ie, we can't add the conversion handler attributes to them).

Rather than reinstating the events system, what I have here is something similar to how TypeDescriptor works in that it allows you to register a handler for a type at runtime. The syntax for this is:

    Ditto.RegisterConversionHandler<MyObject, MyHandler>();

What this is saying is during the conversion of any object of type MyObject run the MyHandler conversion handler during it's conversion.

One thing @leekelleher and I were unsure of was the use of the Ditto prefix. It's intention is to be a facade to give access to non .As methods such that everything is accessed from a single location and you don't get into the thing of trying to remember where you register handlers (kinda the same reason we have everything sit direct on the Our.Umbraco.Ditto namespace, to keep things simple).

Another question kind of arrises from this in that should we also add the ability to register ValueResolvers globally? And possibly TypeConverters (this could just be a method that calls TypeDescriptor.AddAttributes(...) but might be nice to add it to Ditto facade just so everything can be accessed from one location.

Wadda you think?