### PR TITLE
Enabled DittoConverter to pass back IPublishedContent 

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoConverter.cs
@@ -9,7 +9,7 @@ namespace Our.Umbraco.Ditto
     using System;
     using System.ComponentModel;
     using System.Globalization;
-
+    using System.Collections.Generic;
     using global::Umbraco.Core;
     using global::Umbraco.Core.Models;
     using global::Umbraco.Web;
@@ -38,7 +38,13 @@ namespace Our.Umbraco.Ditto
                 return null;
             }
 
-            return UmbracoContext.Current.ContentCache.GetById(id).As(targetType, culture);
+            IPublishedContent content = UmbracoContext.Current.ContentCache.GetById(id);
+
+            // If we're expecting IPublishedContent then just return
+            if (targetType == typeof(IPublishedContent))
+                return content;
+
+            return content.As(targetType, culture);
         }
 
         /// <summary>
@@ -63,8 +69,17 @@ namespace Our.Umbraco.Ditto
             // Ensure we are actually returning a media file.
             if (media.HasProperty(Constants.Conventions.Media.File))
             {
+                // If we're expecting IPublishedContent then just return
+                if (targetType == typeof(IPublishedContent))
+                    return media;
+
                 return media.As(targetType, culture);
             }
+
+
+            // If we're expecting IPublishedContent then just return
+            if (targetType == typeof(IEnumerable<IPublishedContent>))
+                return media.Children();
 
             // It's most likely a folder, try its children.
             // This returns an IEnumerable<T>

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoConverter.cs
@@ -78,7 +78,7 @@ namespace Our.Umbraco.Ditto
 
 
             // If we're expecting IPublishedContent then just return
-            if (targetType == typeof(IEnumerable<IPublishedContent>))
+            if (targetType.IsEnumerableOfType(typeof(IPublishedContent)))
                 return media.Children();
 
             // It's most likely a folder, try its children.

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -331,7 +331,7 @@
                                 () =>
                                 {
                                     // Get the value from Umbraco.
-                                    object propertyValue = GetResovledValue(content, culture, deferredPropertyInfo, localInstance, valueResolverContexts);
+                                    object propertyValue = GetResolvedValue(content, culture, deferredPropertyInfo, localInstance, valueResolverContexts);
                                     return GetConvertedValue(content, culture, deferredPropertyInfo, propertyValue, localInstance);
                                 }));
                     }
@@ -366,7 +366,7 @@
 
                         // Set the value normally.
                         // ReSharper disable once PossibleMultipleEnumeration
-                        object propertyValue = GetResovledValue(content, culture, propertyInfo, instance, valueResolverContexts);
+                        object propertyValue = GetResolvedValue(content, culture, propertyInfo, instance, valueResolverContexts);
                         object result = GetConvertedValue(content, culture, propertyInfo, propertyValue, instance);
 
                         propertyInfo.SetValue(instance, result, null);
@@ -392,7 +392,7 @@
         /// A collection of <see cref="DittoValueResolverContext"/> entities to use whilst resolving values.
         /// </param>
         /// <returns>The <see cref="object"/> representing the Umbraco value.</returns>
-        private static object GetResovledValue(
+        private static object GetResolvedValue(
             IPublishedContent content,
             CultureInfo culture,
             PropertyInfo propertyInfo,


### PR DESCRIPTION
Enabled DittoConverter to pass back IPublishedContent if the targetType is specified as such

Also fixed a typo on a private method...

Use Case:
I have a Content Model (Slide) that has an image and a target node as IPublishedContent Properties (because I don't know what type of node it is) and had to use the DittoMediaPickerConverter as not supplying a converter resulted in a null value coming back from the integer value that is the contentId.

This fix enabled the converters to pass back the resolved IPublishedContent successfully.