### PR TITLE
Rejected TypeConverter value returns null

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 0.8.0.{build}
+version: 0.8.1.{build}
 
 # UMBRACO_PACKAGE_PRERELEASE_SUFFIX if a rtm release build this should be blank, otherwise if empty will default to alpha
 # example UMBRACO_PACKAGE_PRERELEASE_SUFFIX=beta

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -587,6 +587,12 @@
                                     }
                                 }
                             }
+                            else if (propertyType.IsInstanceOfType(propertyValue))
+                            {
+                                // If the TypeConverter's `CanConvertFrom` has returned false,
+                                // then we can check if the value is the same type as the target type.
+                                result = propertyValue;
+                            }
                         }
                     }
                 }

--- a/tests/Our.Umbraco.Ditto.Tests/ClassLevelTypeConverterTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ClassLevelTypeConverterTests.cs
@@ -1,0 +1,99 @@
+﻿namespace Our.Umbraco.Ditto.Tests
+{
+	using System;
+	using System.ComponentModel;
+	using System.Globalization;
+	using NUnit.Framework;
+	using Our.Umbraco.Ditto.Tests.Mocks;
+
+	[TestFixture]
+	public class ClassLevelTypeConverterTests
+	{
+		[TypeConverter(typeof(MyCustomConverter))]
+		public class MyCustomModel
+		{
+			public MyCustomModel(string name)
+			{
+				Name = name;
+			}
+
+			public string Name { get; set; }
+		}
+
+		public class MyModel1
+		{
+			[UmbracoProperty("Name")]
+			public MyCustomModel MyProperty { get; set; }
+		}
+
+		public class MyModel2
+		{
+			[DittoValueResolver(typeof(MyCustomValueResolver))]
+			public MyCustomModel MyProperty { get; set; }
+		}
+
+		public class MyCustomValueResolver : DittoValueResolver
+		{
+			public override object ResolveValue()
+			{
+				return new MyCustomModel("MyCustomName");
+			}
+		}
+
+		public class MyCustomConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			{
+				return sourceType == typeof(string);
+			}
+
+			public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+			{
+				if (value is string)
+					return new MyCustomModel((string)value);
+
+				return base.ConvertFrom(context, culture, value);
+			}
+		}
+
+		[Test]
+		public void ClassLevel_TypeConverter_UmbracoProperty()
+		{
+			// In this test, the `MyProperty` property gets a `string` value
+			// via the `UmbracoProperty`. The `string` type/value is passed
+			// to the `MyCustomConverter` so to convert the `string` to a
+			// `MyCustomModel` type/object.
+
+			var content = new PublishedContentMock() { Name = "MyName" };
+			var model = content.As<MyModel1>();
+
+			Assert.IsNotNull(model);
+			Assert.IsInstanceOf<MyModel1>(model);
+
+			Assert.IsNotNull(model.MyProperty);
+			Assert.IsInstanceOf<MyCustomModel>(model.MyProperty);
+			Assert.That(model.MyProperty.Name, Is.EqualTo("MyName"));
+		}
+
+		[Test]
+		public void ClassLevel_TypeConverter_ValueResolver()
+		{
+			// In this test, the `MyProperty` property gets its value from
+			// the `MyCustomValueResolver` (returning a `MyCustomModel`).
+			// The `MyCustomConverter` is called, but fails the
+			// `CanConvertFrom` check, so wouldn't try to convert it.
+			// Since the value type is the same as the target property type,
+			// the property value can be set.
+
+			var content = new PublishedContentMock() { Name = "MyName" };
+			var model = content.As<MyModel2>();
+
+			Assert.IsNotNull(model);
+			Assert.IsInstanceOf<MyModel2>(model);
+
+			Assert.IsNotNull(model.MyProperty);
+			Assert.IsInstanceOf<MyCustomModel>(model.MyProperty);
+			Assert.That(model.MyProperty.Name, Is.EqualTo("MyCustomName"));
+		}
+	}
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -214,6 +214,7 @@
     <Compile Include="CaseSensitivityTests.cs" />
     <Compile Include="BasicMappingTests.cs" />
     <Compile Include="CastableInterfaceTests.cs" />
+    <Compile Include="ClassLevelTypeConverterTests.cs" />
     <Compile Include="CustomTypeConverterTests.cs" />
     <Compile Include="ConversionHandlerTests.cs" />
     <Compile Include="CustomValueResolverTests.cs" />


### PR DESCRIPTION
I found that if a TypeConverter's `CanConvertFrom` returns false, then the property's value is assigned a `null` reference.

I have added a fix, so that we check if the value type matches the target property's type, then we can assigned it.

It's probably easier to review the attached unit-test: [`ClassLevelTypeConverterTests`](https://github.com/leekelleher/umbraco-ditto/blob/hotfix-0.8.1/tests/Our.Umbraco.Ditto.Tests/ClassLevelTypeConverterTests.cs)
