### PR TITLE
Generic Dictionary detected as Enumerable

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/Internal/TypeInferenceExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/Internal/TypeInferenceExtensions.cs
@@ -14,12 +14,8 @@
         /// <summary>
         /// Determines whether the specified type is an enumerable of the given argument type.
         /// </summary>
-        /// <param name="type">
-        /// The type.
-        /// </param>
-        /// <param name="typeArgument">
-        /// The generic type argument.
-        /// </param>
+        /// <param name="type">The type.</param>
+        /// <param name="typeArgument">The generic type argument.</param>
         /// <returns>
         /// True if the type is an enumerable of the given argument type otherwise; false.
         /// </returns>
@@ -47,6 +43,45 @@
         public static bool IsEnumerableType(this Type type)
         {
             return type.TryGetElementType(typeof(IEnumerable<>)) != null;
+        }
+
+        /// <summary>
+        /// Determines whether the specified type is an enumerable type containing a 
+        /// key value pair as the generic type parameter.
+        /// <remarks>
+        /// <see cref="M:Enumerable.FirstOrDefault"/> will throw an error when passed an
+        /// <see cref="T:IEnumerable{KeyValuePair{,}}"/> this includes <see cref="T:Dictionary{,}"/>.
+        /// </remarks>
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>
+        /// True if the type is an enumerable type with the generic parameter of a key/value 
+        /// pair otherwise; false.</returns>
+        public static bool IsEnumerableOfKeyValueType(this Type type)
+        {
+            return type.TryGetElementType(typeof(IDictionary<,>)) != null ||
+                (type.IsEnumerableType() && type.IsGenericType && type.GenericTypeArguments.Any()
+                 && type.GenericTypeArguments[0].IsGenericType
+                 && type.GenericTypeArguments[0].GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
+        }
+
+        /// <summary>
+        /// Determines whether the specified type is an enumerable type that is safe to cast
+        /// following processing via a type converter.
+        /// <remarks>
+        /// This should exclude <see cref="T:string"/>, <see cref="T:Dictionary{,}"/>
+        /// </remarks>
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns>True if the type is a cast-safe, enumerable type otherwise; false.</returns>
+        public static bool IsCastableEnumerableType(this Type type)
+        {
+            // String, though enumerable have no generic arguments.
+            // Types with more than one generic argument cnnot be cast. 
+            // Dictionary, though enumerable, requires linq to convert and shouldn't be attempted anyway.
+            return type.IsEnumerableType() && type.GenericTypeArguments.Any()
+                    && type.GenericTypeArguments.Length == 1
+                    && type.TryGetElementType(typeof(IDictionary<,>)) == null;
         }
 
         /// <summary>

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -488,8 +488,8 @@
             var propertyType = propertyInfo.PropertyType;
             var typeInfo = propertyType.GetTypeInfo();
 
-            // This should return false against typeof(string) also.
-            var propertyIsEnumerableType = propertyType.IsEnumerableType() && typeInfo.GenericTypeArguments.Any();
+            // This should return false against typeof(string) etc also.
+            var propertyIsEnumerableType = propertyType.IsCastableEnumerableType();
 
             // Try any custom type converters first.
             // 1: Check the property.
@@ -563,8 +563,10 @@
                                     else
                                     {
                                         // Return single expected items from converters returning an IEnumerable.
-                                        // Check for string.
-                                        if (convertedType.IsEnumerableType() && !(convertedType == typeof(string) && propertyType == typeof(string)))
+                                        // Check for key/value pairs and strings.
+                                        if (convertedType.IsEnumerableType()
+                                            && !convertedType.IsEnumerableOfKeyValueType()
+                                            && !(convertedType == typeof(string) && propertyType == typeof(string)))
                                         {
                                             // Use 'FirstOrDefault' to convert the type back to T.
                                             result = EnumerableInvocations.FirstOrDefault(

--- a/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs
@@ -1,58 +1,58 @@
 ﻿namespace Our.Umbraco.Ditto.Tests
 {
-	using System;
-	using System.Collections.Generic;
-	using System.ComponentModel;
-	using System.Globalization;
-	using System.Linq;
-	using System.Text;
-	using System.Threading.Tasks;
-	using NUnit.Framework;
-	using Our.Umbraco.Ditto.Tests.Mocks;
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Globalization;
+    using System.Linq;
+    using NUnit.Framework;
+    using Our.Umbraco.Ditto.Tests.Mocks;
 
-	[TestFixture]
-	public class EnumerableDetectionTests
-	{
-		public class MyModel
-		{
-			[TypeConverter(typeof(MyConverter))]
-			public Dictionary<string, string> MyProperty { get; set; }
-		}
+    [TestFixture]
+    public class EnumerableDetectionTests
+    {
+        public class MyModel
+        {
+            [TypeConverter(typeof(MyConverter))]
+            public Dictionary<string, string> MyProperty { get; set; }
+        }
 
-		public class MyConverter : TypeConverter
-		{
-			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			{
-				return true;
-			}
+        public class MyConverter : TypeConverter
+        {
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            {
+                return true;
+            }
 
-			public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-			{
-				return new Dictionary<string, string>
-				{
-					{ "hello", "world" },
-					{ "foo", "bar" }
-				};
-			}
-		}
+            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            {
+                return new Dictionary<string, string>
+                {
+                    { "hello", "world" },
+                    { "foo", "bar" }
+                };
+            }
+        }
 
-		[Test]
-		public void GenericDictionary_Property_Is_Detected_As_Enumerable()
-		{
-			var property = new PublishedContentPropertyMock
-			{
-				Alias = "myProperty",
-				Value = "myValue"
-			};
+        [Test]
+        public void GenericDictionaryPropertyIsNotDetectedAsCastableEnumerable()
+        {
+            var property = new PublishedContentPropertyMock
+            {
+                Alias = "myProperty",
+                Value = "myValue"
+            };
 
-			var content = new PublishedContentMock
-			{
-				Properties = new[] { property }
-			};
+            var content = new PublishedContentMock
+            {
+                Properties = new[] { property }
+            };
 
-			TestDelegate code = () => { content.As<MyModel>(); };
+            var result = content.As<MyModel>();
 
-			Assert.Throws<ArgumentException>(code);
-		}
-	}
+            Assert.NotNull(result.MyProperty);
+            Assert.True(result.MyProperty.Any());
+            Assert.AreEqual(result.MyProperty["hello"], "world");
+        }
+    }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs
@@ -1,0 +1,58 @@
+﻿namespace Our.Umbraco.Ditto.Tests
+{
+	using System;
+	using System.Collections.Generic;
+	using System.ComponentModel;
+	using System.Globalization;
+	using System.Linq;
+	using System.Text;
+	using System.Threading.Tasks;
+	using NUnit.Framework;
+	using Our.Umbraco.Ditto.Tests.Mocks;
+
+	[TestFixture]
+	public class EnumerableDetectionTests
+	{
+		public class MyModel
+		{
+			[TypeConverter(typeof(MyConverter))]
+			public Dictionary<string, string> MyProperty { get; set; }
+		}
+
+		public class MyConverter : TypeConverter
+		{
+			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			{
+				return true;
+			}
+
+			public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+			{
+				return new Dictionary<string, string>
+				{
+					{ "hello", "world" },
+					{ "foo", "bar" }
+				};
+			}
+		}
+
+		[Test]
+		public void GenericDictionary_Property_Is_Detected_As_Enumerable()
+		{
+			var property = new PublishedContentPropertyMock
+			{
+				Alias = "myProperty",
+				Value = "myValue"
+			};
+
+			var content = new PublishedContentMock
+			{
+				Properties = new[] { property }
+			};
+
+			TestDelegate code = () => { content.As<MyModel>(); };
+
+			Assert.Throws<ArgumentException>(code);
+		}
+	}
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -217,6 +217,7 @@
     <Compile Include="CustomTypeConverterTests.cs" />
     <Compile Include="ConversionHandlerTests.cs" />
     <Compile Include="CustomValueResolverTests.cs" />
+    <Compile Include="EnumerableDetectionTests.cs" />
     <Compile Include="GlobalValueResolverTests.cs" />
     <Compile Include="PrefixedPropertyTests.cs" />
     <Compile Include="ValueResolverContextTests.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/TypeInferenceTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/TypeInferenceTests.cs
@@ -59,6 +59,51 @@
         }
 
         /// <summary>
+        /// Tests the <see cref="TypeInferenceExtensions.IsEnumerableType"/> method.
+        /// </summary>
+        /// <param name="input">The input <see cref="Type"/>.</param>
+        /// <param name="expected">The expected result.
+        /// </param>
+        [Test]
+        [TestCase(typeof(string), false)]
+        [TestCase(typeof(bool), false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(long), false)]
+        [TestCase(typeof(List<string>), true)]
+        [TestCase(typeof(Collection<string>), true)]
+        [TestCase(typeof(HashSet<string>), true)]
+        [TestCase(typeof(Enumerable), false)]
+        [TestCase(typeof(Dictionary<string, string>), false)]
+        public void TestIsCastableEnumerableType(Type input, bool expected)
+        {
+            Assert.AreEqual(input.IsCastableEnumerableType(), expected);
+        }
+
+        /// <summary>
+        /// Tests the <see cref="TypeInferenceExtensions.IsEnumerableType"/> method.
+        /// </summary>
+        /// <param name="input">The input <see cref="Type"/>.</param>
+        /// <param name="expected">The expected result.
+        /// </param>
+        [Test]
+        [TestCase(typeof(string), false)]
+        [TestCase(typeof(bool), false)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(long), false)]
+        [TestCase(typeof(List<string>), false)]
+        [TestCase(typeof(Collection<string>), false)]
+        [TestCase(typeof(HashSet<string>), false)]
+        [TestCase(typeof(Enumerable), false)]
+        [TestCase(typeof(Dictionary<string, string>), true)]
+        [TestCase(typeof(List<KeyValuePair<string, string>>), true)]
+        [TestCase(typeof(Collection<KeyValuePair<string, string>>), true)]
+        [TestCase(typeof(HashSet<KeyValuePair<string, string>>), true)]
+        public void TestIsEnumerableOfKeyValueType(Type input, bool expected)
+        {
+            Assert.AreEqual(input.IsEnumerableOfKeyValueType(), expected);
+        }
+
+        /// <summary>
         /// Tests the <see cref="TypeInferenceExtensions.IsEnumerableOfType"/> method.
         /// <remarks>
         /// Resharper doesn't work properly if the first parameter is an array.


### PR DESCRIPTION
I've stumped up on a bug with how Ditto is determining if a property is an `Enumerable` type.

If a property is using a generic `Dictionary<T1, T2>` type, Ditto will attempt to cast the value as `Enumerable<T1>`.

I've added a unit-test to verify this scenario, see [`EnumerableDetectionTests`](https://github.com/leekelleher/umbraco-ditto/blob/bug/enumerable-detection/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs), I think it's easier to explain in code.

Here's an example of the exception thrown...

```
Test Name:	GenericDictionary_Property_Is_Detected_As_Enumerable
Test FullName:	Our.Umbraco.Ditto.Tests.EnumerableDetectionTests.GenericDictionary_Property_Is_Detected_As_Enumerable
Test Source:	x:\umbraco-ditto\tests\Our.Umbraco.Ditto.Tests\EnumerableDetectionTests.cs : line 41
Test Outcome:	Failed
Test Duration:	0:01:52.941

Result Message:	System.ArgumentException : Object of type 'System.Linq.Enumerable+<CastIterator>d__b1`1[System.String]' cannot be converted to type 'System.Collections.Generic.Dictionary`2[System.String,System.String]'.
Result StackTrace:	
at System.RuntimeType.TryChangeType(Object value, Binder binder, CultureInfo culture, Boolean needsSpecialCast)
at System.RuntimeType.CheckValue(Object value, Binder binder, CultureInfo culture, BindingFlags invokeAttr)
at System.Reflection.MethodBase.CheckArguments(Object[] parameters, Binder binder, BindingFlags invokeAttr, CultureInfo culture, Signature sig)
at System.Reflection.RuntimeMethodInfo.InvokeArgumentsCheck(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, BindingFlags invokeAttr, Binder binder, Object[] index, CultureInfo culture)
at System.Reflection.RuntimePropertyInfo.SetValue(Object obj, Object value, Object[] index)
at Our.Umbraco.Ditto.PublishedContentExtensions.ConvertContent(IPublishedContent content, Type type, CultureInfo culture, Object instance, IEnumerable`1 valueResolverContexts, Action`1 onConverting, Action`1 onConverted) in x:\umbraco-ditto\src\Our.Umbraco.Ditto\Extensions\PublishedContentExtensions.cs:line 383
at Our.Umbraco.Ditto.PublishedContentExtensions.As(IPublishedContent content, Type type, CultureInfo culture, Object instance, IEnumerable`1 valueResolverContexts, Action`1 onConverting, Action`1 onConverted) in x:\umbraco-ditto\src\Our.Umbraco.Ditto\Extensions\PublishedContentExtensions.cs:line 202
at Our.Umbraco.Ditto.PublishedContentExtensions.As[T](IPublishedContent content, CultureInfo culture, T instance, IEnumerable`1 valueResolverContexts, Action`1 onConverting, Action`1 onConverted) in x:\umbraco-ditto\src\Our.Umbraco.Ditto\Extensions\PublishedContentExtensions.cs:line 76
at Our.Umbraco.Ditto.Tests.EnumerableDetectionTests.GenericDictionary_Property_Is_Detected_As_Enumerable() in x:\umbraco-ditto\tests\Our.Umbraco.Ditto.Tests\EnumerableDetectionTests.cs:line 53
```

@JimBobSquarePants I've assigned it to you, as I think it is up your street.  Feel free to add to this `bug/enumerable-detection` branch with any fixes, etc.