### PR TITLE
Fixes DittoConversionHandlerRegistry cache type-cast

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerRegistry.cs
@@ -67,7 +67,7 @@
                 }
                 else
                 {
-                    Cache.Add(objType, new[] { handlerType });
+                    Cache.Add(objType, new List<Type> { handlerType });
                 }
             }
         }

--- a/tests/Our.Umbraco.Ditto.Tests/MultipleConversionHandlerTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/MultipleConversionHandlerTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Our.Umbraco.Ditto.Tests
+{
+    using NUnit.Framework;
+    using Our.Umbraco.Ditto.Tests.Mocks;
+
+    [TestFixture]
+    public class MultipleConversionHandlerTests
+    {
+        public class MyModel
+        {
+            public string Name { get; set; }
+        }
+
+        public class MyModelConversionHandler : DittoConversionHandler<MyModel>
+        {
+            public override void OnConverted()
+            {
+                Model.Name = "foo";
+            }
+        }
+
+        public class MyModelConversionHandler2 : DittoConversionHandler<MyModel>
+        {
+            public override void OnConverted()
+            {
+                Model.Name += " bar";
+            }
+        }
+
+        [Test]
+        public void Multiple_Conversion_Handlers_Registered_Same_Type()
+        {
+            Ditto.RegisterConversionHandler<MyModel, MyModelConversionHandler>();
+            Ditto.RegisterConversionHandler<MyModel, MyModelConversionHandler2>();
+
+            var content = new PublishedContentMock();
+
+            var model = content.As<MyModel>();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.Name, Is.EqualTo("foo bar"));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -219,6 +219,7 @@
     <Compile Include="ConversionHandlerTests.cs" />
     <Compile Include="CustomValueResolverTests.cs" />
     <Compile Include="GlobalValueResolverTests.cs" />
+    <Compile Include="MultipleConversionHandlerTests.cs" />
     <Compile Include="PrefixedPropertyTests.cs" />
     <Compile Include="ValueResolverContextTests.cs" />
     <Compile Include="CurrentContentTests.cs" />


### PR DESCRIPTION
The value type for `DittoConversionHandlerRegistry`'s internal `Cache` was being cast as an array, rather than a `List<Type>`.

This lead to a `NotSupportedException` ("Collection was of a fixed size.") when registering multiple conversion-handlers.

I've added a unit-test to support this fix.

@mattbrailsford I've assigned to you for a sanity check.