### PR TITLE
Custom PublishedContent property nullifies value

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoPropertyValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoPropertyValueResolver.cs
@@ -59,9 +59,16 @@
             if (!umbracoPropertyName.IsNullOrWhiteSpace())
             {
                 var contentProperty = contentType.GetProperty(umbracoPropertyName, BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static);
-                propertyValue = contentProperty != null
-                    ? contentProperty.GetValue(content, null)
-                    : content.GetPropertyValue(umbracoPropertyName, recursive);
+
+                if (contentProperty != null)
+                {
+                    propertyValue = contentProperty.GetValue(content, null);
+                }
+
+                if (propertyValue == null)
+                {
+                    propertyValue = content.GetPropertyValue(umbracoPropertyName, recursive);
+                }
             }
 
             // Try fetching the alt value.

--- a/tests/Our.Umbraco.Ditto.Tests/CustomPublishedContentPropertyTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/CustomPublishedContentPropertyTests.cs
@@ -1,0 +1,40 @@
+﻿namespace Our.Umbraco.Ditto.Tests
+{
+    using Mocks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CustomPublishedContentPropertyTests
+    {
+        public class CustomPublishedContentMock : PublishedContentMock
+        {
+            public string MyProperty { get; set; }
+        }
+
+        public class MyModel
+        {
+            public string MyProperty { get; set; }
+        }
+
+        [Test]
+        public void CustomPublishedContent_Property_IsMapped()
+        {
+            var value = "myValue";
+
+            var property = new PublishedContentPropertyMock
+            {
+                Alias = "myProperty",
+                Value = value
+            };
+
+            var content = new CustomPublishedContentMock
+            {
+                Properties = new[] { property }
+            };
+
+            var model = content.As<MyModel>();
+
+            Assert.That(model.MyProperty, Is.EqualTo(value));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -215,6 +215,7 @@
     <Compile Include="BasicMappingTests.cs" />
     <Compile Include="CastableInterfaceTests.cs" />
     <Compile Include="ClassLevelTypeConverterTests.cs" />
+    <Compile Include="CustomPublishedContentPropertyTests.cs" />
     <Compile Include="CustomTypeConverterTests.cs" />
     <Compile Include="ConversionHandlerTests.cs" />
     <Compile Include="CustomValueResolverTests.cs" />


### PR DESCRIPTION
@Jeavon [raised an issue on Gitter](https://gitter.im/leekelleher/umbraco-ditto?at=5603f6cbe85e8d337252aa51) about Ditto not mapping the value of a property when using a custom `IPublishedContent` that has a property with the same name.

I have modified the `UmbracoPropertyValueResolver` to handle this scenario, (and included a supporting unit-test).

We first try to get the value from the `IPublishedContent` object property, then if the value is null, we make a call to the content's `GetPropertyValue` method.

---

@JimBobSquarePants @mattbrailsford Could either of you cast an eye over this change and scenario, (most as a sanity check), thanks.

@Jeavon If you want to try out a custom build from this branch to confirm that this works for you?