### PR TITLE
InternalsVisibleTo vs make some internals public?

### DIFF
--- a/src/Our.Umbraco.Ditto/Properties/AssemblyInfo.cs
+++ b/src/Our.Umbraco.Ditto/Properties/AssemblyInfo.cs
@@ -14,4 +14,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("C3A53472-6FBC-42ED-ABD4-5B1594C32E98")]
 
+[assembly: InternalsVisibleTo("Our.Umbraco.Ditto.Archetype")]
 [assembly: InternalsVisibleTo("Our.Umbraco.Ditto.Tests")]


### PR DESCRIPTION
I've been experimenting with Archetype support on Ditto Labs...

https://github.com/leekelleher/umbraco-ditto-labs/tree/develop/src/Our.Umbraco.Ditto.Archetype

...and the more I attempt to produce a similar developer experience (DX?) to Ditto, I'm finding that I am copying over a lot of code, since much of Ditto is marked as `internal`.

My quick fix to this would be to add the `InternalsVisibleTo` attribute to Ditto for the Archetype lab project.  Alternatively, should we explore making certain classes `public`?

...or say "it's not a Ditto concern, suck it up Lee!"? :stuck_out_tongue_winking_eye: 
