### PR TITLE
Unit-test for ImageCropDataSet

### DIFF
--- a/tests/Our.Umbraco.Ditto.Tests/ImageCropDataSetMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ImageCropDataSetMappingTests.cs
@@ -1,0 +1,36 @@
+﻿namespace Our.Umbraco.Ditto.Tests
+{
+    using Newtonsoft.Json;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ImageCropDataSetMappingTests
+    {
+        public class MyModel
+        {
+            public Models.ImageCropDataSet MyProperty { get; set; }
+        }
+
+        [Test]
+        public void ImageCropDataSetMappedTest()
+        {
+            // JSON test data taken from Umbraco unit-test:
+            // https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Tests/PropertyEditors/ImageCropperTest.cs
+            var json = "{\"focalPoint\": {\"left\": 0.96,\"top\": 0.80827067669172936},\"src\": \"/media/1005/img_0671.jpg\",\"crops\": [{\"alias\":\"thumb\",\"width\": 100,\"height\": 100,\"coordinates\": {\"x1\": 0.58729977382575338,\"y1\": 0.055768992440203169,\"x2\": 0,\"y2\": 0.32457553600198386}}]}";
+            var value = JsonConvert.DeserializeObject<Models.ImageCropDataSet>(json);
+
+            Assert.That(value, Is.Not.Null);
+
+            var property = new Mocks.PublishedContentPropertyMock("myProperty", value, true);
+            var content = new Mocks.PublishedContentMock { Properties = new[] { property } };
+
+            var model = content.As<MyModel>();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.MyProperty, Is.Not.Null);
+            Assert.That(model.MyProperty, Is.EqualTo(value));
+            Assert.That(model.MyProperty.Crops, Is.Not.Null.Or.Empty);
+            Assert.That(model.MyProperty.Src, Is.Not.Null.Or.Empty);
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Models/ImageCropModels.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Models/ImageCropModels.cs
@@ -1,0 +1,54 @@
+﻿/// <summary>
+/// The ImageCrop* models were introduced in Umbraco v7.0+.
+/// Since we are compiling/testing Ditto against Umbraco v6.2.5,
+/// we do not have access to the ImageCrop* models.
+/// They have been reproduced here for testing purposes.
+/// </summary>
+namespace Our.Umbraco.Ditto.Tests.Models
+{
+    using System.Collections.Generic;
+    using System.Web;
+
+    public class ImageCropDataSet : IHtmlString
+    {
+        public string Src { get; set; }
+
+        public ImageCropFocalPoint FocalPoint { get; set; }
+
+        public IEnumerable<ImageCropData> Crops { get; set; }
+
+        public string ToHtmlString()
+        {
+            return this.Src;
+        }
+    }
+
+    public class ImageCropData
+    {
+        public string Alias { get; set; }
+
+        public int Width { get; set; }
+
+        public int Height { get; set; }
+
+        public ImageCropCoordinates Coordinates { get; set; }
+    }
+
+    public class ImageCropFocalPoint
+    {
+        public decimal Left { get; set; }
+
+        public decimal Top { get; set; }
+    }
+
+    public class ImageCropCoordinates
+    {
+        public decimal X1 { get; set; }
+
+        public decimal Y1 { get; set; }
+
+        public decimal X2 { get; set; }
+
+        public decimal Y2 { get; set; }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -221,6 +221,8 @@
     <Compile Include="CustomValueResolverTests.cs" />
     <Compile Include="EnumerableDetectionTests.cs" />
     <Compile Include="GlobalValueResolverTests.cs" />
+    <Compile Include="ImageCropDataSetMappingTests.cs" />
+    <Compile Include="Models\ImageCropModels.cs" />
     <Compile Include="MultipleConversionHandlerTests.cs" />
     <Compile Include="PocoConstructorTests.cs" />
     <Compile Include="PrefixedPropertyTests.cs" />


### PR DESCRIPTION
Discussions around ImageCrop values/models keep arising, this unit-test is intended to clarify that the values can be mapped using Ditto.

Opening as PR, so to allow for any discussion. Do we need this unit-test in the Ditto core?