### PR TITLE
Deprecate legacy Ditto TypeConverters?

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoContentPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoContentPickerConverter.cs
@@ -10,6 +10,7 @@
     /// <summary>
     /// Provides a unified way of converting content picker properties to strong typed model.
     /// </summary>
+    [Obsolete("This converter has been deprecated, please use the DittoPickerConverter instead.", false)]
     public class DittoContentPickerConverter : DittoConverter
     {
         /// <summary>

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoMediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoMediaPickerConverter.cs
@@ -10,6 +10,7 @@
     /// <summary>
     /// Provides a unified way of converting media picker properties to strong typed model.
     /// </summary>
+    [Obsolete("This converter has been deprecated, please use the DittoPickerConverter instead.", false)]
     public class DittoMediaPickerConverter : DittoConverter
     {
         /// <summary>

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoMemberPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoMemberPickerConverter.cs
@@ -10,6 +10,7 @@
     /// <summary>
     /// Provides a unified way of converting member picker properties to strong typed model.
     /// </summary>
+    [Obsolete("This converter has been deprecated, please use the DittoPickerConverter instead.", false)]
     public class DittoMemberPickerConverter : DittoConverter
     {
         /// <summary>

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoMultipleMediaPickerConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoMultipleMediaPickerConverter.cs
@@ -11,6 +11,7 @@
     /// <summary>
     /// Provides a unified way of converting multi media picker properties to strong typed collections.
     /// </summary>
+    [Obsolete("This converter has been deprecated, please use the DittoPickerConverter instead.", false)]
     public class DittoMultipleMediaPickerConverter : DittoConverter
     {
         /// <summary>


### PR DESCRIPTION
Following on from issue #127 ...

Marked the legacy TypeConverters with the `Obsolete` attribute, as they have been superseded by `DittoPickerConverter`.

Are we happy with the warning message?

    "This converter has been deprecated, please use the DittoPickerConverter instead."