### PR TITLE
Switch out TypeConverter to allow serialization.

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoTypeConverterAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoTypeConverterAttribute.cs
@@ -1,0 +1,93 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+
+    /// <summary>
+    /// Specifies what type to use as a converter for the object this attribute is bound to. 
+    /// This class cannot be inherited.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.All)]
+    public sealed class DittoTypeConverterAttribute : Attribute
+    {
+        /// <summary>
+        /// Specifies the type to use as a converter for the object this attribute is bound to. 
+        /// This <see langword="static"/>field is read-only.
+        /// </summary>
+        public static readonly DittoTypeConverterAttribute Default = new DittoTypeConverterAttribute();
+
+        /// <summary>
+        /// The name of the type to use as a converter for the object this attribute is bound to.
+        /// </summary>
+        private readonly string typeName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoTypeConverterAttribute"/> class.
+        /// </summary>
+        public DittoTypeConverterAttribute()
+        {
+            this.typeName = string.Empty;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoTypeConverterAttribute"/> class.
+        /// </summary>
+        /// <param name="type">
+        /// The <see cref="System.Type"/> to use as a converter for the object this attribute is bound to.
+        /// </param>
+        public DittoTypeConverterAttribute(Type type)
+        {
+            this.typeName = type.AssemblyQualifiedName;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoTypeConverterAttribute"/> class.
+        /// </summary>
+        /// <param name="typeName">
+        /// The name of the <see cref="System.Type"/> to use as a converter for the object this attribute is bound to.
+        /// </param>
+        public DittoTypeConverterAttribute(string typeName)
+        {
+            string temp = typeName.ToUpper(CultureInfo.InvariantCulture);
+            Debug.Assert(temp.IndexOf(".DLL", StringComparison.Ordinal) == -1, "Came across: " + typeName + " . Please remove the .dll extension");
+            this.typeName = typeName;
+        }
+
+        /// <summary>
+        /// Gets the fully qualified type name of the <see cref="System.Type"/>
+        /// to use as a converter for the object this attribute is bound to.
+        /// </summary>
+        public string ConverterTypeName
+        {
+            get
+            {
+                return this.typeName;
+            }
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether this instance is equal to a specified object.
+        /// </summary>
+        /// <returns>
+        /// true if <paramref name="obj"/> equals the type and value of this instance; otherwise, false.
+        /// </returns>
+        /// <param name="obj">An <see cref="T:System.Object"/> to compare with this instance or null. </param>
+        public override bool Equals(object obj)
+        {
+            DittoTypeConverterAttribute other = obj as DittoTypeConverterAttribute;
+            return (other != null) && other.ConverterTypeName == this.typeName;
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A 32-bit signed integer hash code.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return this.typeName.GetHashCode();
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/DittoConverter.cs
@@ -8,6 +8,7 @@ namespace Our.Umbraco.Ditto
 {
     using System;
     using System.ComponentModel;
+    using System.ComponentModel.Design.Serialization;
     using System.Globalization;
 
     using global::Umbraco.Core;
@@ -19,8 +20,65 @@ namespace Our.Umbraco.Ditto
     /// The Ditto type converter containing reusable properties and methods for converting <see cref="IPublishedContent"/> instances.
     /// All other Ditto converters should inherit from this class.
     /// </summary>
-    public abstract class DittoConverter : TypeConverter
+    public abstract class DittoConverter : IDittoTypeConverter
     {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter,
+        /// using the specified context.
+        /// </summary>
+        /// <param name="context">
+        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
+        /// </param>
+        /// <param name="sourceType">
+        /// A <see cref="T:System.Type" /> that represents the type you want to convert from.
+        /// </param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        public virtual bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            // Taken from TypeConverter.cs
+            if (sourceType == typeof(InstanceDescriptor))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        public virtual object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            // Taken from TypeConverter.cs
+            InstanceDescriptor descriptor = value as InstanceDescriptor;
+
+            if (descriptor != null)
+            {
+                return descriptor.Invoke();
+            }
+
+            string valueTypeName;
+
+            if (value == null)
+            {
+                valueTypeName = "null";
+            }
+            else
+            {
+                valueTypeName = value.GetType().FullName;
+            }
+
+            throw new NotSupportedException(string.Format("Cannot convert {0} using {1}.", valueTypeName, this.GetType().Name));
+        }
+
         /// <summary>
         /// Takes a content node ID, gets the corresponding <see cref="T:Umbraco.Core.Models.IPublishedContent"/> object,
         /// then converts the object to the desired type.

--- a/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/IDittoTypeConverter.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/TypeConverters/IDittoTypeConverter.cs
@@ -1,0 +1,38 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+
+    /// <summary>
+    /// Encapsulates methods for converting the Umbraco objects into different data types.
+    /// </summary>
+    public interface IDittoTypeConverter
+    {
+        /// <summary>
+        /// Returns whether this converter can convert an object of the given type to the type of this converter,
+        /// using the specified context.
+        /// </summary>
+        /// <param name="context">
+        /// An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.
+        /// </param>
+        /// <param name="sourceType">
+        /// A <see cref="T:System.Type" /> that represents the type you want to convert from.
+        /// </param>
+        /// <returns>
+        /// true if this converter can perform the conversion; otherwise, false.
+        /// </returns>
+        bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType);
+
+        /// <summary>
+        /// Converts the given object to the type of this converter, using the specified context and culture information.
+        /// </summary>
+        /// <param name="context">An <see cref="T:System.ComponentModel.ITypeDescriptorContext" /> that provides a format context.</param>
+        /// <param name="culture">The <see cref="T:System.Globalization.CultureInfo" /> to use as the current culture.</param>
+        /// <param name="value">The <see cref="T:System.Object" /> to convert.</param>
+        /// <returns>
+        /// An <see cref="T:System.Object" /> that represents the converted value.
+        /// </returns>
+        object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value);
+    }
+}

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -496,9 +496,9 @@
             // 2: Check any type arguments in generic enumerable types.
             // 3: Check the type itself.
             var converterAttribute =
-                propertyInfo.GetCustomAttribute<TypeConverterAttribute>()
-                ?? (propertyIsEnumerableType ? typeInfo.GenericTypeArguments.First().GetCustomAttribute<TypeConverterAttribute>(true)
-                                             : propertyType.GetCustomAttribute<TypeConverterAttribute>(true));
+                propertyInfo.GetCustomAttribute<DittoTypeConverterAttribute>()
+                ?? (propertyIsEnumerableType ? typeInfo.GenericTypeArguments.First().GetCustomAttribute<DittoTypeConverterAttribute>(true)
+                                             : propertyType.GetCustomAttribute<DittoTypeConverterAttribute>(true));
 
             if (converterAttribute != null && converterAttribute.ConverterTypeName != null)
             {
@@ -509,7 +509,7 @@
                     var converterType = Type.GetType(converterAttribute.ConverterTypeName);
                     if (converterType != null)
                     {
-                        var converter = converterType.GetDependencyResolvedInstance() as TypeConverter;
+                        var converter = converterType.GetDependencyResolvedInstance() as IDittoTypeConverter;
 
                         if (converter != null)
                         {
@@ -603,7 +603,7 @@
             {
                 // Handle Html strings so we don't have to set the attribute.
                 var converterType = typeof(DittoHtmlStringConverter);
-                var converter = converterType.GetDependencyResolvedInstance() as TypeConverter;
+                var converter = converterType.GetDependencyResolvedInstance() as IDittoTypeConverter;
 
                 if (converter != null)
                 {

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -87,6 +87,7 @@
     <Compile Include="ComponentModel\Attributes\DittoOnConvertedAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\CurrentContentAsAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoIgnoreAttribute.cs" />
+    <Compile Include="ComponentModel\Attributes\DittoTypeConverterAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoValueResolverAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\UmbracoDictionaryAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\UmbracoPropertiesAttribute.cs" />
@@ -107,6 +108,7 @@
     <Compile Include="ComponentModel\TypeConverters\DittoMediaPickerConverter.cs" />
     <Compile Include="ComponentModel\TypeConverters\DittoContentPickerConverter.cs" />
     <Compile Include="ComponentModel\TypeConverters\DittoHtmlStringConverter.cs" />
+    <Compile Include="ComponentModel\TypeConverters\IDittoTypeConverter.cs" />
     <Compile Include="ComponentModel\ValueResolvers\AppSettingValueResolver.cs" />
     <Compile Include="ComponentModel\ValueResolvers\CurrentContentAsValueResolver.cs" />
     <Compile Include="ComponentModel\ValueResolvers\DittoValueResolverRegistry.cs" />

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj.DotSettings
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj.DotSettings
@@ -3,6 +3,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=attributes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=common/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel_005Cattributes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel_005Cconversionhandlers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel_005Ctypeconverters/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=componentmodel_005Cvalueresolvers/@EntryIndexedValue">True</s:Boolean>

--- a/tests/Our.Umbraco.Ditto.Tests/ClassLevelTypeConverterTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ClassLevelTypeConverterTests.cs
@@ -1,99 +1,99 @@
 ﻿namespace Our.Umbraco.Ditto.Tests
 {
-	using System;
-	using System.ComponentModel;
-	using System.Globalization;
-	using NUnit.Framework;
-	using Our.Umbraco.Ditto.Tests.Mocks;
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using NUnit.Framework;
+    using Our.Umbraco.Ditto.Tests.Mocks;
 
-	[TestFixture]
-	public class ClassLevelTypeConverterTests
-	{
-		[TypeConverter(typeof(MyCustomConverter))]
-		public class MyCustomModel
-		{
-			public MyCustomModel(string name)
-			{
-				Name = name;
-			}
+    [TestFixture]
+    public class ClassLevelTypeConverterTests
+    {
+        [DittoTypeConverter(typeof(MyCustomConverter))]
+        public class MyCustomModel
+        {
+            public MyCustomModel(string name)
+            {
+                Name = name;
+            }
 
-			public string Name { get; set; }
-		}
+            public string Name { get; set; }
+        }
 
-		public class MyModel1
-		{
-			[UmbracoProperty("Name")]
-			public MyCustomModel MyProperty { get; set; }
-		}
+        public class MyModel1
+        {
+            [UmbracoProperty("Name")]
+            public MyCustomModel MyProperty { get; set; }
+        }
 
-		public class MyModel2
-		{
-			[DittoValueResolver(typeof(MyCustomValueResolver))]
-			public MyCustomModel MyProperty { get; set; }
-		}
+        public class MyModel2
+        {
+            [DittoValueResolver(typeof(MyCustomValueResolver))]
+            public MyCustomModel MyProperty { get; set; }
+        }
 
-		public class MyCustomValueResolver : DittoValueResolver
-		{
-			public override object ResolveValue()
-			{
-				return new MyCustomModel("MyCustomName");
-			}
-		}
+        public class MyCustomValueResolver : DittoValueResolver
+        {
+            public override object ResolveValue()
+            {
+                return new MyCustomModel("MyCustomName");
+            }
+        }
 
-		public class MyCustomConverter : TypeConverter
-		{
-			public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-			{
-				return sourceType == typeof(string);
-			}
+        public class MyCustomConverter : DittoConverter
+        {
+            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            {
+                return sourceType == typeof(string);
+            }
 
-			public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-			{
-				if (value is string)
-					return new MyCustomModel((string)value);
+            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            {
+                if (value is string)
+                    return new MyCustomModel((string)value);
 
-				return base.ConvertFrom(context, culture, value);
-			}
-		}
+                return base.ConvertFrom(context, culture, value);
+            }
+        }
 
-		[Test]
-		public void ClassLevel_TypeConverter_UmbracoProperty()
-		{
-			// In this test, the `MyProperty` property gets a `string` value
-			// via the `UmbracoProperty`. The `string` type/value is passed
-			// to the `MyCustomConverter` so to convert the `string` to a
-			// `MyCustomModel` type/object.
+        [Test]
+        public void ClassLevel_TypeConverter_UmbracoProperty()
+        {
+            // In this test, the `MyProperty` property gets a `string` value
+            // via the `UmbracoProperty`. The `string` type/value is passed
+            // to the `MyCustomConverter` so to convert the `string` to a
+            // `MyCustomModel` type/object.
 
-			var content = new PublishedContentMock() { Name = "MyName" };
-			var model = content.As<MyModel1>();
+            var content = new PublishedContentMock() { Name = "MyName" };
+            var model = content.As<MyModel1>();
 
-			Assert.IsNotNull(model);
-			Assert.IsInstanceOf<MyModel1>(model);
+            Assert.IsNotNull(model);
+            Assert.IsInstanceOf<MyModel1>(model);
 
-			Assert.IsNotNull(model.MyProperty);
-			Assert.IsInstanceOf<MyCustomModel>(model.MyProperty);
-			Assert.That(model.MyProperty.Name, Is.EqualTo("MyName"));
-		}
+            Assert.IsNotNull(model.MyProperty);
+            Assert.IsInstanceOf<MyCustomModel>(model.MyProperty);
+            Assert.That(model.MyProperty.Name, Is.EqualTo("MyName"));
+        }
 
-		[Test]
-		public void ClassLevel_TypeConverter_ValueResolver()
-		{
-			// In this test, the `MyProperty` property gets its value from
-			// the `MyCustomValueResolver` (returning a `MyCustomModel`).
-			// The `MyCustomConverter` is called, but fails the
-			// `CanConvertFrom` check, so wouldn't try to convert it.
-			// Since the value type is the same as the target property type,
-			// the property value can be set.
+        [Test]
+        public void ClassLevel_TypeConverter_ValueResolver()
+        {
+            // In this test, the `MyProperty` property gets its value from
+            // the `MyCustomValueResolver` (returning a `MyCustomModel`).
+            // The `MyCustomConverter` is called, but fails the
+            // `CanConvertFrom` check, so wouldn't try to convert it.
+            // Since the value type is the same as the target property type,
+            // the property value can be set.
 
-			var content = new PublishedContentMock() { Name = "MyName" };
-			var model = content.As<MyModel2>();
+            var content = new PublishedContentMock() { Name = "MyName" };
+            var model = content.As<MyModel2>();
 
-			Assert.IsNotNull(model);
-			Assert.IsInstanceOf<MyModel2>(model);
+            Assert.IsNotNull(model);
+            Assert.IsInstanceOf<MyModel2>(model);
 
-			Assert.IsNotNull(model.MyProperty);
-			Assert.IsInstanceOf<MyCustomModel>(model.MyProperty);
-			Assert.That(model.MyProperty.Name, Is.EqualTo("MyCustomName"));
-		}
-	}
+            Assert.IsNotNull(model.MyProperty);
+            Assert.IsInstanceOf<MyCustomModel>(model.MyProperty);
+            Assert.That(model.MyProperty.Name, Is.EqualTo("MyCustomName"));
+        }
+    }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/CustomTypeConverterTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/CustomTypeConverterTests.cs
@@ -7,17 +7,19 @@
     using Our.Umbraco.Ditto.Tests.Mocks;
     using global::Umbraco.Core.Models;
 
+    using Newtonsoft.Json;
+
     [TestFixture]
     public class CustomTypeConverterTests
     {
         public class MyModel
         {
             [UmbracoProperty("Id")]
-            [TypeConverter(typeof(MyCustomConverter))]
-            public IPublishedContent MyProperty { get; set; }
+            [DittoTypeConverter(typeof(MyCustomConverter))]
+            public virtual IPublishedContent MyProperty { get; set; }
         }
 
-        public class MyCustomConverter : TypeConverter
+        public class MyCustomConverter : DittoConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {
@@ -49,6 +51,26 @@
 
             Assert.That(model.MyProperty, Is.InstanceOf<IPublishedContent>());
             Assert.That(model.MyProperty.Id, Is.EqualTo(id));
+        }
+
+        [Test]
+        public void CanSerializeModelWithTypeAttribute()
+        {
+            var id = 1234;
+
+            var content = new PublishedContentMock()
+            {
+                Id = id
+            };
+
+            var model = content.As<MyModel>();
+
+            Assert.That(model.MyProperty, Is.InstanceOf<IPublishedContent>());
+            Assert.That(model.MyProperty.Id, Is.EqualTo(id));
+
+            var serialized = JsonConvert.SerializeObject(model);
+            Assert.NotNull(serialized);
+            Assert.True(serialized.IndexOf("\"Id\":1234", StringComparison.Ordinal) > -1);
         }
     }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/EnumerableDetectionTests.cs
@@ -13,11 +13,11 @@
     {
         public class MyModel
         {
-            [TypeConverter(typeof(MyConverter))]
+            [DittoTypeConverter(typeof(MyConverter))]
             public Dictionary<string, string> MyProperty { get; set; }
         }
 
-        public class MyConverter : TypeConverter
+        public class MyConverter : DittoConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {

--- a/tests/Our.Umbraco.Ditto.Tests/SingularityMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/SingularityMappingTests.cs
@@ -11,7 +11,7 @@
     {
         public class MyModel
         {
-            [TypeConverter(typeof(DittoPickerConverter))]
+            [DittoTypeConverter(typeof(DittoPickerConverter))]
             public IPublishedContent MyProperty { get; set; }
         }
 


### PR DESCRIPTION
If we attempt to serialize a class using JSON.NET that has a custom
TypeConverter bound the serialization will fail. This can have serious
implications when using ApiControllers. See #124 

This pull request switches out the `TypeConverter` base class and `TypeConverterAttribute` class for a custom `IDittoTypeConverter` and `DittoTypeConverterAttribute` types. 

Unfortunately it seems that we will not be able to maintain backwards compatibility. 

Answers on a postcard!