### PR TITLE
Unit-test for inherited classes with prefixed properties

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/PublishedContentContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/PublishedContentContext.cs
@@ -11,6 +11,11 @@
     public abstract class PublishedContentContext : ITypeDescriptorContext
     {
         /// <summary>
+        /// Gets the object <see cref="T:System.Type"/> of the instance that is being converted.
+        /// </summary>
+        public Type ConversionType { get; internal set; }
+
+        /// <summary>
         /// Gets the object that is connected with this type descriptor request.
         /// </summary>
         /// <returns>

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolverContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolverContext.cs
@@ -1,10 +1,13 @@
 ﻿namespace Our.Umbraco.Ditto
 {
+    using System;
+
     /// <summary>
     /// The Ditto resolver context.
     /// Provides a way of providing contextual information to value resolvers.
     /// </summary>
     public class DittoValueResolverContext : PublishedContentContext
     {
+        public Type ConversionType { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolverContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/DittoValueResolverContext.cs
@@ -1,13 +1,10 @@
 ﻿namespace Our.Umbraco.Ditto
 {
-    using System;
-
     /// <summary>
     /// The Ditto resolver context.
     /// Provides a way of providing contextual information to value resolvers.
     /// </summary>
     public class DittoValueResolverContext : PublishedContentContext
     {
-        public Type ConversionType { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoPropertyValueResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ValueResolvers/UmbracoPropertyValueResolver.cs
@@ -25,9 +25,9 @@
             var altPropName = string.Empty;
 
             // Check for umbraco properties attribute on class
-            if (this.Context.PropertyDescriptor != null)
+            if (this.Context.ConversionType != null)
             {
-                var classAttr = this.Context.PropertyDescriptor.ComponentType
+                var classAttr = this.Context.ConversionType
                     .GetCustomAttribute<UmbracoPropertiesAttribute>();
                 if (classAttr != null)
                 {

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -519,6 +519,7 @@
                             var descriptor = TypeDescriptor.GetProperties(instance)[propertyInfo.Name];
                             var context = new DittoTypeConverterContext
                             {
+                                ConversionType = instance.GetType(),
                                 Instance = content,
                                 PropertyDescriptor = descriptor
                             };
@@ -612,6 +613,7 @@
                     var descriptor = TypeDescriptor.GetProperties(instance)[propertyInfo.Name];
                     var context = new DittoTypeConverterContext
                     {
+                        ConversionType = instance.GetType(),
                         Instance = content,
                         PropertyDescriptor = descriptor
                     };

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -459,6 +459,7 @@
                 }
 
                 // Populate internal context properties
+                context.ConversionType = instance.GetType();
                 context.Instance = content;
                 context.PropertyDescriptor = TypeDescriptor.GetProperties(instance)[propertyInfo.Name];
 

--- a/tests/Our.Umbraco.Ditto.Tests/InheritedClassWithPrefixedPropertyTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/InheritedClassWithPrefixedPropertyTests.cs
@@ -1,0 +1,31 @@
+﻿namespace Our.Umbraco.Ditto.Tests
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class InheritedClassWithPrefixedPropertyTests
+    {
+        public class BasicModel
+        {
+            public string MyProperty { get; set; }
+        }
+
+        [UmbracoProperties(Prefix = "inherited_")]
+        public class InheritedModel : BasicModel
+        {
+        }
+
+        [Test]
+        public void InheritedClassWithPrefixedProperty_Mapping()
+        {
+            var value = "foo bar";
+            var property = new Mocks.PublishedContentPropertyMock("inherited_myProperty", value, true);
+            var content = new Mocks.PublishedContentMock() { Properties = new[] { property } };
+
+            var model = content.As<InheritedModel>();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.MyProperty, Is.EqualTo(value));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -222,6 +222,7 @@
     <Compile Include="EnumerableDetectionTests.cs" />
     <Compile Include="GlobalValueResolverTests.cs" />
     <Compile Include="ImageCropDataSetMappingTests.cs" />
+    <Compile Include="InheritedClassWithPrefixedPropertyTests.cs" />
     <Compile Include="JsonSerializationWithTypeConverterTests.cs" />
     <Compile Include="Models\ImageCropModels.cs" />
     <Compile Include="MultipleConversionHandlerTests.cs" />


### PR DESCRIPTION
Added a unit-test to verify the issue raised in #132 by @jamiepollock

The problem is that the Context in `UmbracoPropertyValueResolver` is not aware of the derived class.

It only knows about the `ComponentType`, which is the class that the property is bound to, (e.g. the inherited/base class).