### PR TITLE
Testing IPublishedContent with IsEnumerableOfType extension method

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/Internal/TypeInferenceExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/Internal/TypeInferenceExtensions.cs
@@ -22,7 +22,7 @@
         public static bool IsEnumerableOfType(this Type type, Type typeArgument)
         {
             Type t = type.TryGetElementType(typeof(IEnumerable<>));
-            return t != null && t.IsAssignableFrom(typeArgument);
+            return t != null && typeArgument.IsAssignableFrom(t);
         }
 
         /// <summary>

--- a/tests/Our.Umbraco.Ditto.Tests/TypeInferenceTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/TypeInferenceTests.cs
@@ -6,6 +6,7 @@
     using System.Linq;
 
     using NUnit.Framework;
+    using global::Umbraco.Core.Models;
 
     /// <summary>
     /// The type inference tests.
@@ -121,6 +122,7 @@
         [TestCase(typeof(string), typeof(string), false)]
         [TestCase(typeof(string), typeof(char), true)]
         [TestCase(typeof(Dictionary<string, string>), typeof(KeyValuePair<string, string>), true)]
+        [TestCase(typeof(IEnumerable<Mocks.PublishedContentMock>), typeof(IPublishedContent), true, TestName = "TestIsEnumerableOfType: Derived IPublishedContent")]
         public void TestIsEnumerableOfType(Type input, Type argumentType, bool expected)
         {
             Assert.AreEqual(input.IsEnumerableOfType(argumentType), expected);


### PR DESCRIPTION
Hey @JimBobSquarePants, here's one for you :smirk_cat: 

Whilst experimenting with returning collections of a custom `IPublishedContent` class, Ditto wouldn't attempt to cast/map them any further.

I set up a quick unit-test to see if this was the case... (where `PublishedContentMock` is a custom implementation of `IPublishedContent`)

```
typeof(IEnumerable<Mocks.PublishedContentMock>).IsEnumerableOfType(typeof(IPublishedContent))
```

Should this be true or false?

---

I've added in a fix that swaps around the params for the `IsAssignableFrom` check.