### PR TITLE
Default Processor Type

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoDefaultProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoDefaultProcessorAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// The Ditto default processor attribute.
+    /// Used for specifying that Ditto should use a default processor during object conversion.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class DittoDefaultProcessorAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoDefaultProcessorAttribute"/> class.
+        /// </summary>
+        /// <param name="processorType">Type of the processor</param>
+        public DittoDefaultProcessorAttribute(Type processorType)
+        {
+            this.ProcessorType = processorType;
+        }
+
+        /// <summary>
+        /// Gets the type of the processor.
+        /// </summary>
+        /// <value>
+        /// The type of the processor.
+        /// </value>
+        public Type ProcessorType { get; set; }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Our.Umbraco.Ditto
 {
     /// <summary>
-    /// Registry for globally registered value resolvers.
+    /// Registry for globally registered processors.
     /// </summary>
     internal class DittoProcessorRegistry
     {
@@ -13,6 +14,11 @@ namespace Our.Umbraco.Ditto
         /// The cache for storing handler information.
         /// </summary>
         private static readonly Dictionary<Type, List<DittoProcessorAttribute>> Cache = new Dictionary<Type, List<DittoProcessorAttribute>>();
+
+        /// <summary>
+        /// The default processor type, (defaults to `UmbracoProperty`).
+        /// </summary>
+        private Type DefaultProcessorType = typeof(UmbracoPropertyAttribute);
 
         /// <summary>
         /// Static holder for singleton instance.
@@ -46,6 +52,16 @@ namespace Our.Umbraco.Ditto
         }
 
         /// <summary>
+        /// Registeres the default processor attribute.
+        /// </summary>
+        /// <typeparam name="TProcessorAttributeType"></typeparam>
+        public void RegisterDefaultProcessorType<TProcessorAttributeType>()
+            where TProcessorAttributeType : DittoProcessorAttribute, new()
+        {
+            this.DefaultProcessorType = typeof(TProcessorAttributeType);
+        }
+
+        /// <summary>
         /// Registers the processor attribute.
         /// </summary>
         /// <typeparam name="TObjectType">The type of the object type.</typeparam>
@@ -76,6 +92,24 @@ namespace Our.Umbraco.Ditto
 
                 Cache[objType].Add(instance);
             }
+        }
+
+        /// <summary>
+        /// Gets the default processor attribute type for the given object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// Returns the default processor attribute type for the given object type.
+        /// </returns>
+        public Type GetDefaultProcessorType(Type objectType)
+        {
+            var attr = objectType.GetCustomAttribute<DittoDefaultProcessorAttribute>();
+            if (attr != null)
+            {
+                return attr.ProcessorType;
+            }
+
+            return this.DefaultProcessorType;
         }
 
         /// <summary>

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -33,6 +33,16 @@ namespace Our.Umbraco.Ditto
         }
 
         /// <summary>
+        /// Registers the default processor type.
+        /// </summary>
+        /// <typeparam name="TProcessorAttributeType">The type of the processor attribute type.</typeparam>
+        public static void RegisterDefaultProcessorType<TProcessorAttributeType>()
+            where TProcessorAttributeType : DittoProcessorAttribute, new()
+        {
+            DittoProcessorRegistry.Instance.RegisterDefaultProcessorType<TProcessorAttributeType>();
+        }
+
+        /// <summary>
         /// Registers a global value resolver attribute.
         /// </summary>
         /// <typeparam name="TObjectType">The type of the object being converted.</typeparam>

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -82,6 +82,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ComponentModel\Attributes\DittoDefaultProcessorAttribute.cs" />
     <Compile Include="ComponentModel\Caching\DittoCacheContext.cs" />
     <Compile Include="ComponentModel\Attributes\DittoCacheableAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoCacheAttribute.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/DefaultProcessorTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/DefaultProcessorTests.cs
@@ -1,0 +1,74 @@
+﻿using NUnit.Framework;
+using Umbraco.Core.Models;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    public class DefaultProcessorTests
+    {
+        public class MyModel
+        {
+            public string Name { get; set; }
+        }
+
+        [DittoDefaultProcessor(typeof(MyCustomProcessorAttribute))]
+        public class MyCustomModel
+        {
+            public string Name { get; set; }
+        }
+
+        public class MyCustomProcessorAttribute : DittoProcessorAttribute
+        {
+            public override object ProcessValue()
+            {
+                return "MyCustomName";
+            }
+        }
+
+        public class MyGlobalProcessorAttribute : DittoProcessorAttribute
+        {
+            public override object ProcessValue()
+            {
+                return "MyGlobalName";
+            }
+        }
+
+        public IPublishedContent PublishedContent { get; set; }
+
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            var name = "MyName";
+            this.PublishedContent = new Mocks.PublishedContentMock { Name = name };
+        }
+
+        [Test]
+        public void Default_Processor_IsUsed()
+        {
+            var model = this.PublishedContent.As<MyModel>();
+
+            Assert.That(model.Name, Is.EqualTo("MyName"));
+        }
+
+        [Test]
+        public void Default_Processor_ClassLevel_IsUsed()
+        {
+            var model = this.PublishedContent.As<MyCustomModel>();
+
+            Assert.That(model.Name, Is.EqualTo("MyCustomName"));
+        }
+
+        [Test]
+        public void Default_Processor_GlobalLevel_IsUsed()
+        {
+            Ditto.RegisterDefaultProcessorType<MyGlobalProcessorAttribute>();
+
+            var model = this.PublishedContent.As<MyModel>();
+
+            Assert.That(model.Name, Is.EqualTo("MyGlobalName"));
+
+            // tidy-up after test, otherwise the new default processor will cause other tests to fail!
+            Ditto.RegisterDefaultProcessorType<UmbracoPropertyAttribute>();
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -220,6 +220,7 @@
     <Compile Include="CurrentContentTests.cs" />
     <Compile Include="CustomPublishedContentPropertyTests.cs" />
     <Compile Include="CustomValueResolverTests.cs" />
+    <Compile Include="DefaultProcessorTests.cs" />
     <Compile Include="EnumerableDetectionTests.cs" />
     <Compile Include="EnumerableTests.cs" />
     <Compile Include="ExistingObjectInstanceTests.cs" />


### PR DESCRIPTION
Proposed solution to issue #151

Adds a way to register the default processor type, either globally or at class-level.

Includes unit-tests to support this feature.