### PR TITLE
Fast property accessors

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,8 @@ We also have a [MyGet package repository](https://www.myget.org/gallery/umbraco-
 
 If you prefer, you can compile Ditto yourself, you'll need:
 
-* Visual Studio 2012 (or above)
+* [Visual Studio 2012 (or above, including Community Editions)](https://www.visualstudio.com/downloads/)
+* Microsoft Build Tools 2013 (aka [MSBuild 12](https://www.microsoft.com/en-us/download/details.aspx?id=40760))
 
 To clone it locally run the following git commands:
 

--- a/src/Our.Umbraco.Ditto.PerformanceTests/App.config
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    </startup>
+</configuration>

--- a/src/Our.Umbraco.Ditto.PerformanceTests/Our.Umbraco.Ditto.PerformanceTests.csproj
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/Our.Umbraco.Ditto.PerformanceTests.csproj
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7409ADFA-56F9-4A18-9208-0EEBC696F46B}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Our.Umbraco.Ditto.PerformanceTests</RootNamespace>
+    <AssemblyName>Umbraco.PerformanceTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.4\lib\net45\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Our.Umbraco.Ditto\Our.Umbraco.Ditto.csproj">
+      <Project>{3a2482a4-ad19-4c26-a449-4287da07ab16}</Project>
+      <Name>Our.Umbraco.Ditto</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Our.Umbraco.Ditto.PerformanceTests/Program.cs
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/Program.cs
@@ -17,8 +17,6 @@ using BenchmarkDotNet.Running;
 
 namespace Our.Umbraco.Ditto.PerformanceTests
 {
-
-
     public class Program
     {
         public class DittoPerformance

--- a/src/Our.Umbraco.Ditto.PerformanceTests/Program.cs
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/Program.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.ComponentModel;
+using System.Reflection;
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Running;
+
+namespace Our.Umbraco.Ditto.PerformanceTests
+{
+
+
+    public class Program
+    {
+        public class DittoPerformance
+        {
+            private DittoPerformance obj;
+
+            private dynamic dlr;
+            private PropertyInfo prop;
+            private PropertyDescriptor descriptor;
+
+            public string Value { get; set; }
+
+            public static void Main(string[] args)
+            {
+                var summary = BenchmarkRunner.Run<DittoPerformance>(new Config());
+                Console.WriteLine();
+
+                // Display a summary to match the output of the original Performance test
+                foreach (var report in summary.Reports.OrderBy(r => r.Key.Target.MethodTitle))
+                {
+                    Console.WriteLine("{0}: {1:N2} ns", report.Key.Target.MethodTitle, report.Value.ResultStatistics.Median);
+                }
+
+                Console.WriteLine();
+            }
+
+            [Setup]
+            public void Setup()
+            {
+                this.obj = new DittoPerformance();
+                this.dlr = this.obj;
+                this.prop = typeof(DittoPerformance).GetProperty("Value");
+                this.descriptor = TypeDescriptor.GetProperties(this.obj)["Value"];
+            }
+
+            [Benchmark(Description = "1. Static C#", Baseline = true)]
+            public string StaticCSharp()
+            {
+                this.obj.Value = "abc";
+                return this.obj.Value;
+            }
+
+            [Benchmark(Description = "2. Dynamic C#")]
+            public string DynamicCSharp()
+            {
+                this.dlr.Value = "abc";
+                return this.dlr.Value;
+            }
+
+            [Benchmark(Description = "3. PropertyInfo")]
+            public string PropertyInfo()
+            {
+                this.prop.SetValue(this.obj, "abc", null);
+                return (string)this.prop.GetValue(this.obj, null);
+            }
+
+            [Benchmark(Description = "4. PropertyDescriptor")]
+            public string PropertyDescriptor()
+            {
+                this.descriptor.SetValue(this.obj, "abc");
+                return (string)this.descriptor.GetValue(this.obj);
+            }
+
+            [Benchmark(Description = "5. PropertyInfoInvocations")]
+            public string PropertyInvocations()
+            {
+                PropertyInfoInvocations.SetValue(this.prop, this.obj, "abc");
+                return (string)PropertyInfoInvocations.GetValue(this.prop, this.obj);
+            }
+        }
+
+        // BenchmarkDotNet settings (you can use the defaults, but these are tailored for this benchmark)
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                this.Add(Job.Default.WithLaunchCount(1));
+                this.Add(PropertyColumn.Method);
+                this.Add(StatisticColumn.Median, StatisticColumn.StdDev);
+                this.Add(BaselineDiffColumn.Scaled);
+                this.Add(CsvExporter.Default, MarkdownExporter.Default, MarkdownExporter.GitHub);
+                this.Add(new ConsoleLogger());
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto.PerformanceTests/Properties/AssemblyInfo.cs
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/Properties/AssemblyInfo.cs
@@ -1,36 +1,16 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Our.Umbraco.Ditto.PerformanceTests")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Performance tests for Ditto")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Our.Umbraco.Ditto.PerformanceTests")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCompany("Umbraco Community")]
+[assembly: AssemblyProduct("Ditto")]
+[assembly: AssemblyCopyright("Copyright \xa9 Umbraco Community 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+[assembly: Guid("7409ADFA-56F9-4A18-9208-0EEBC696F46B")]
 
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("7409adfa-56f9-4a18-9208-0eebc696f46b")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.*")]

--- a/src/Our.Umbraco.Ditto.PerformanceTests/Properties/AssemblyInfo.cs
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Our.Umbraco.Ditto.PerformanceTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Our.Umbraco.Ditto.PerformanceTests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7409adfa-56f9-4a18-9208-0eebc696f46b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Our.Umbraco.Ditto.PerformanceTests/packages.config
+++ b/src/Our.Umbraco.Ditto.PerformanceTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BenchmarkDotNet" version="0.9.4" targetFramework="net45" />
+</packages>

--- a/src/Our.Umbraco.Ditto.sln
+++ b/src/Our.Umbraco.Ditto.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.Ditto", "Our.Umbraco.Ditto\Our.Umbraco.Ditto.csproj", "{3A2482A4-AD19-4C26-A449-4287DA07AB16}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6CF4E7DA-6359-479E-A64D-2023C743BA1C}"
@@ -39,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		..\docs\usage-basic.md = ..\docs\usage-basic.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Our.Umbraco.Ditto.PerformanceTests", "Our.Umbraco.Ditto.PerformanceTests\Our.Umbraco.Ditto.PerformanceTests.csproj", "{7409ADFA-56F9-4A18-9208-0EEBC696F46B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +57,10 @@ Global
 		{8F71EB63-C2E5-4391-8FFC-6EEF6BD9BD54}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F71EB63-C2E5-4391-8FFC-6EEF6BD9BD54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F71EB63-C2E5-4391-8FFC-6EEF6BD9BD54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7409ADFA-56F9-4A18-9208-0EEBC696F46B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7409ADFA-56F9-4A18-9208-0EEBC696F46B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7409ADFA-56F9-4A18-9208-0EEBC696F46B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7409ADFA-56F9-4A18-9208-0EEBC696F46B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Our.Umbraco.Ditto/Common/CachedInvocations.cs
+++ b/src/Our.Umbraco.Ditto/Common/CachedInvocations.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Our.Umbraco.Ditto
+{
+    using System.Collections.Concurrent;
+    using System.Runtime.CompilerServices;
+
+    internal class CachedInvocations
+    {
+        /// <summary>
+        /// The method cache for storing function implementations.
+        /// </summary>
+        protected static readonly ConcurrentDictionary<MethodBaseCacheItem, Func<object, object>> FunctionCache
+            = new ConcurrentDictionary<MethodBaseCacheItem, Func<object, object>>();
+
+        /// <summary>
+        /// The method cache for storing action implementations.
+        /// </summary>
+        protected static readonly ConcurrentDictionary<MethodBaseCacheItem, Action<object, object>> ActionCache
+            = new ConcurrentDictionary<MethodBaseCacheItem, Action<object, object>>();
+
+        /// <summary>
+        /// Returns a cache key for the given method and type.
+        /// </summary>
+        /// <param name="type">
+        /// The <see cref="object"/> the key reflects.
+        /// </param>
+        /// <param name="memberName">
+        /// The method name. Generated at compile time.
+        /// </param>
+        /// <returns>
+        /// The <see cref="MethodBaseCacheItem"/> for the given method and type.
+        /// </returns>
+        protected static MethodBaseCacheItem GetMethodCacheKey(object type, [CallerMemberName] string memberName = null)
+        {
+            return new MethodBaseCacheItem(memberName, type);
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Common/EnumerableInvocations.cs
+++ b/src/Our.Umbraco.Ditto/Common/EnumerableInvocations.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -14,14 +13,9 @@ namespace Our.Umbraco.Ditto
     /// Once a method is invoked for a given type then it is cached so that subsequent calls do not require
     /// any overhead compilation costs.
     /// </summary>
-    internal static class EnumerableInvocations
+    // ReSharper disable once ClassNeverInstantiated.Global
+    internal class EnumerableInvocations : CachedInvocations
     {
-        /// <summary>
-        /// The method cache for storing function implementations.
-        /// </summary>
-        private static readonly ConcurrentDictionary<MethodBaseCacheItem, Func<object, object>> Cache
-            = new ConcurrentDictionary<MethodBaseCacheItem, Func<object, object>>();
-
         /// <summary>
         /// The cast method.
         /// </summary>
@@ -61,10 +55,10 @@ namespace Our.Umbraco.Ditto
             var key = GetMethodCacheKey(type);
 
             Func<object, object> f;
-            if (!Cache.TryGetValue(key, out f))
+            if (!FunctionCache.TryGetValue(key, out f))
             {
                 f = StaticMethodSingleParameter<object>(CastMethod.MakeGenericMethod(type));
-                Cache[key] = f;
+                FunctionCache[key] = f;
             }
 
             return f(value);
@@ -85,10 +79,10 @@ namespace Our.Umbraco.Ditto
             var key = GetMethodCacheKey(type);
 
             Func<object, object> f;
-            if (!Cache.TryGetValue(key, out f))
+            if (!FunctionCache.TryGetValue(key, out f))
             {
                 f = StaticMethod<object>(EmptyMethod.MakeGenericMethod(type));
-                Cache[key] = f;
+                FunctionCache[key] = f;
             }
 
             return f(type);
@@ -109,10 +103,10 @@ namespace Our.Umbraco.Ditto
             var key = GetMethodCacheKey(type);
 
             Func<object, object> f;
-            if (!Cache.TryGetValue(key, out f))
+            if (!FunctionCache.TryGetValue(key, out f))
             {
                 f = StaticMethodSingleParameter<object>(FirstOrDefaultMethod.MakeGenericMethod(type));
-                Cache[key] = f;
+                FunctionCache[key] = f;
             }
 
             return f(Cast(type, value));
@@ -167,23 +161,6 @@ namespace Our.Umbraco.Ditto
             return Expression.Lambda<Func<T, object>>(
                    Expression.Convert(methodCall, typeof(object)),
                    argument).Compile();
-        }
-
-        /// <summary>
-        /// Returns a cache key for the given method and type.
-        /// </summary>
-        /// <param name="type">
-        /// The <see cref="Type"/> the key reflects.
-        /// </param>
-        /// <param name="memberName">
-        /// The method name. Generated at compile time.
-        /// </param>
-        /// <returns>
-        /// The <see cref="MethodBaseCacheItem"/> for the given method and type.
-        /// </returns>
-        private static MethodBaseCacheItem GetMethodCacheKey(Type type, [CallerMemberName] string memberName = null)
-        {
-            return new MethodBaseCacheItem(memberName, type);
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Common/MethodBaseCacheItem.cs
+++ b/src/Our.Umbraco.Ditto/Common/MethodBaseCacheItem.cs
@@ -15,14 +15,14 @@ namespace Our.Umbraco.Ditto
         /// <summary>
         /// Gets or sets the type.
         /// </summary>
-        public readonly Type Type;
+        public readonly object Type;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MethodBaseCacheItem"/> struct.
         /// </summary>
         /// <param name="methodBase">The method base.</param>
-        /// <param name="type">The type.</param>
-        public MethodBaseCacheItem(string methodBase, Type type)
+        /// <param name="type">The object type or property.</param>
+        public MethodBaseCacheItem(string methodBase, object type)
         {
             this.MethodBase = methodBase;
             this.Type = type;

--- a/src/Our.Umbraco.Ditto/Common/PropertyInfoInvocations.cs
+++ b/src/Our.Umbraco.Ditto/Common/PropertyInfoInvocations.cs
@@ -1,0 +1,109 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    using System;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    /// <summary>
+    /// Provides a way to set a properties value using delegates. 
+    /// This is much faster than <see cref="M:PropertyInfo.SetValue"/> as it avois the normal overheads of reflection.
+    /// Once a method is invoked for a given type then it is cached so that subsequent calls do not require
+    /// any overhead compilation costs.
+    /// </summary>
+    // ReSharper disable once ClassNeverInstantiated.Global
+    internal class PropertyInfoInvocations : CachedInvocations
+    {
+        /// <summary>
+        /// Gets the value of the property on the given instance. 
+        /// </summary>
+        /// <param name="property">The property to set.</param>
+        /// <param name="instance">The current instance to return the property from.</param>
+        /// <returns>The <see cref="object"/> value.</returns>
+        public static object GetValue(PropertyInfo property, object instance)
+        {
+            var key = GetMethodCacheKey(property);
+
+            Func<object, object> a;
+            if (!FunctionCache.TryGetValue(key, out a))
+            {
+                a = BuildGetAccessor(property.GetGetMethod());
+                FunctionCache[key] = a;
+            }
+
+           return a(instance);
+        }
+
+        /// <summary>
+        /// Set the value of the property on the given instance. 
+        /// </summary>
+        /// <param name="property">The property to set.</param>
+        /// <param name="instance">The current instance to assign the property to.</param>
+        /// <param name="value">The value to set.</param>
+        public static void SetValue(PropertyInfo property, object instance, object value)
+        {
+            var key = GetMethodCacheKey(property);
+
+            Action<object, object> a;
+            if (!ActionCache.TryGetValue(key, out a))
+            {
+                a = BuildSetAccessor(property.GetSetMethod());
+                ActionCache[key] = a;
+            }
+
+            a(instance, value);
+        }
+
+        /// <summary>
+        /// Builds the get accessor for the given type.
+        /// </summary>
+        /// <param name="method">The method to compile.</param>
+        /// <returns>The <see cref="Action{Object, Object}"/></returns>
+        private static Func<object, object> BuildGetAccessor(MethodInfo method)
+        {
+            var obj = Expression.Parameter(typeof(object), "o");
+
+            if (method.DeclaringType != null)
+            {
+                Expression<Func<object, object>> expr =
+                    Expression.Lambda<Func<object, object>>(
+                        Expression.Convert(
+                            Expression.Call(
+                                Expression.Convert(obj, method.DeclaringType),
+                                method),
+                            typeof(object)),
+                        obj);
+
+                return expr.Compile();
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Builds the set accessor for the given type.
+        /// </summary>
+        /// <param name="method">The method to compile.</param>
+        /// <returns>The <see cref="Action{Object, Object}"/></returns>
+        private static Action<object, object> BuildSetAccessor(MethodInfo method)
+        {
+            var obj = Expression.Parameter(typeof(object), "o");
+            var value = Expression.Parameter(typeof(object));
+
+            if (method.DeclaringType != null)
+            {
+                Expression<Action<object, object>> expr =
+                    Expression.Lambda<Action<object, object>>(
+                        Expression.Call(
+                            Expression.Convert(obj, method.DeclaringType),
+                            method,
+                            Expression.Convert(value, method.GetParameters()[0].ParameterType)),
+                        obj,
+                        value);
+
+                return expr.Compile();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
@@ -120,7 +120,8 @@ namespace Our.Umbraco.Ditto
 
                 if (contentProperty != null)
                 {
-                    propertyValue = contentProperty.GetValue(content, null);
+                    // This is more than 2x as fast as propertyValue = contentProperty.GetValue(content, null);
+                    propertyValue = PropertyInfoInvocations.GetValue(contentProperty, content);
                 }
 
                 if (propertyValue == null)
@@ -137,7 +138,8 @@ namespace Our.Umbraco.Ditto
 
                 if (contentProperty != null)
                 {
-                    propertyValue = contentProperty.GetValue(content, null);
+                    // This is more than 2x as fast as propertyValue = contentProperty.GetValue(content, null);
+                    propertyValue = PropertyInfoInvocations.GetValue(contentProperty, content);
                 }
 
                 if (propertyValue == null)

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -383,7 +383,8 @@ namespace Our.Umbraco.Ditto
                         // ReSharper disable once PossibleMultipleEnumeration
                         var value = GetProcessedValue(content, culture, type, propertyInfo, instance, defaultProcessorType, processorContexts);
 
-                        propertyInfo.SetValue(instance, value, null);
+                        // This is 2x as fast as propertyInfo.SetValue(instance, value, null);
+                        PropertyInfoInvocations.SetValue(propertyInfo, instance, value);
                     }
                 }
             }

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -82,6 +82,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\CachedInvocations.cs" />
+    <Compile Include="Common\PropertyInfoInvocations.cs" />
     <Compile Include="ComponentModel\Attributes\DittoDefaultProcessorAttribute.cs" />
     <Compile Include="ComponentModel\Caching\DittoCacheContext.cs" />
     <Compile Include="ComponentModel\Attributes\DittoCacheableAttribute.cs" />

--- a/src/Our.Umbraco.Ditto/Properties/AssemblyInfo.cs
+++ b/src/Our.Umbraco.Ditto/Properties/AssemblyInfo.cs
@@ -15,3 +15,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("C3A53472-6FBC-42ED-ABD4-5B1594C32E98")]
 
 [assembly: InternalsVisibleTo("Umbraco.Tests")]
+[assembly: InternalsVisibleTo("Umbraco.PerformanceTests")]

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -253,7 +253,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <Choose>


### PR DESCRIPTION
Add compiled cached PropertyInfo accessors and benchmarking code.

This more than doubles the speed on my machine. Hopefully it should do the same on everyone else's. I'd love to see if somehow we could use the performance of dynamic but as far as I'm aware there's no way to get or set the properties without knowing the name at compile time.

:horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: :horse_racing: 

```
// * Summary *

BenchmarkDotNet=v0.9.4.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=AMD A6-3410MX APU with Radeon(tm) HD Graphics, ProcessorCount=4
Frequency=14318180 ticks, Resolution=69.8413 ns, Timer=HPET
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1073.0


                     Method |        Median |     StdDev | Scaled |
--------------------------- |-------------- |----------- |------- |
               1. Static C# |     6.6731 ns |  0.0695 ns |   1.00 |
              2. Dynamic C# |    83.2365 ns |  0.4543 ns |  12.47 |
            3. PropertyInfo | 1,080.9561 ns | 37.0885 ns | 161.99 |
      4. PropertyDescriptor | 2,339.9117 ns | 81.9432 ns | 350.65 |
 5. PropertyInfoInvocations |   410.3465 ns |  3.9585 ns |  61.49 | #Whoop!

// ***** BenchmarkRunner: End *****

1. Static C#: 6.67 ns
2. Dynamic C#: 83.24 ns
3. PropertyInfo: 1,080.96 ns
4. PropertyDescriptor: 2,339.91 ns
5. PropertyInfoInvocations: 410.35 ns
```