### PR TITLE
Unit-test UmbracoPicker processor

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPickerAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPickerAttribute.cs
@@ -24,27 +24,16 @@ namespace Our.Umbraco.Ditto
         public override object ProcessValue()
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (Context == null || Context.PropertyDescriptor == null)
+            if (Context == null || Context.PropertyDescriptor == null || Value.IsNullOrEmptyString())
             {
                 return Enumerable.Empty<object>();
-            }
-
-            var propertyType = Context.PropertyDescriptor.PropertyType;
-            var isGenericType = propertyType.IsGenericType;
-            var targetType = isGenericType
-                                ? propertyType.GenericTypeArguments.First()
-                                : propertyType;
-
-            if (Value.IsNullOrEmptyString())
-            {
-                return EnumerableInvocations.Empty(targetType);
             }
 
             // Single IPublishedContent
             IPublishedContent content = Value as IPublishedContent;
             if (content != null)
             {
-                return content.As(targetType, Context.Culture);
+                return content;
             }
 
             // ReSharper disable once PossibleNullReferenceException
@@ -53,7 +42,7 @@ namespace Our.Umbraco.Ditto
             // Multiple IPublishedContent
             if (type.IsEnumerableOfType(typeof(IPublishedContent)))
             {
-                return ((IEnumerable<IPublishedContent>)Value).As(targetType, Context.Culture);
+                return ((IEnumerable<IPublishedContent>)Value);
             }
 
             int[] nodeIds = { };
@@ -113,7 +102,7 @@ namespace Our.Umbraco.Ditto
                     }
                 }
 
-                return multiPicker.As(targetType, Context.Culture);
+                return multiPicker;
             }
 
             return null;

--- a/tests/Our.Umbraco.Ditto.Tests/Mocks/MockHttpContext.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Mocks/MockHttpContext.cs
@@ -1,0 +1,9 @@
+﻿using System.Web;
+
+namespace Our.Umbraco.Ditto.Tests.Mocks
+{
+    public class MockHttpContext : HttpContextBase
+    {
+        public override HttpRequestBase Request { get { return null; } }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Mocks/MockPublishedContentCache.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Mocks/MockPublishedContentCache.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.XPath;
+using Umbraco.Core.Models;
+using Umbraco.Core.Xml;
+using Umbraco.Web;
+using Umbraco.Web.PublishedCache;
+
+namespace Our.Umbraco.Ditto.Tests.Mocks
+{
+    public class MockPublishedContentCache : IPublishedContentCache
+    {
+        public bool XPathNavigatorIsNavigable
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IPublishedContent CreateFragment(string contentTypeAlias, IDictionary<string, object> dataValues, bool isPreviewing, bool managed)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IPublishedContent> GetAtRoot(UmbracoContext umbracoContext, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPublishedContent GetById(UmbracoContext umbracoContext, bool preview, int contentId)
+        {
+            return new PublishedContentMock { Id = contentId };
+        }
+
+        public IPublishedContent GetByRoute(UmbracoContext umbracoContext, bool preview, string route, bool? hideTopLevelNode = default(bool?))
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IPublishedContent> GetByXPath(UmbracoContext umbracoContext, bool preview, XPathExpression xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IPublishedContent> GetByXPath(UmbracoContext umbracoContext, bool preview, string xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetRouteById(UmbracoContext umbracoContext, bool preview, int contentId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPublishedContent GetSingleByXPath(UmbracoContext umbracoContext, bool preview, XPathExpression xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPublishedContent GetSingleByXPath(UmbracoContext umbracoContext, bool preview, string xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public XPathNavigator GetXPathNavigator(UmbracoContext umbracoContext, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasContent(UmbracoContext umbracoContext, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Mocks/MockPublishedMediaCache.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Mocks/MockPublishedMediaCache.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.XPath;
+using Umbraco.Core.Models;
+using Umbraco.Core.Xml;
+using Umbraco.Web;
+using Umbraco.Web.PublishedCache;
+
+namespace Our.Umbraco.Ditto.Tests.Mocks
+{
+    public class MockPublishedMediaCache : IPublishedMediaCache
+    {
+        public bool XPathNavigatorIsNavigable
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IEnumerable<IPublishedContent> GetAtRoot(UmbracoContext umbracoContext, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPublishedContent GetById(UmbracoContext umbracoContext, bool preview, int contentId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IPublishedContent> GetByXPath(UmbracoContext umbracoContext, bool preview, XPathExpression xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<IPublishedContent> GetByXPath(UmbracoContext umbracoContext, bool preview, string xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPublishedContent GetSingleByXPath(UmbracoContext umbracoContext, bool preview, XPathExpression xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPublishedContent GetSingleByXPath(UmbracoContext umbracoContext, bool preview, string xpath, XPathVariable[] vars)
+        {
+            throw new NotImplementedException();
+        }
+
+        public XPathNavigator GetXPathNavigator(UmbracoContext umbracoContext, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool HasContent(UmbracoContext umbracoContext, bool preview)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -161,6 +161,7 @@
       <Private>True</Private>
       <HintPath>..\..\src\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
+    <Reference Include="System.XML" />
     <Reference Include="TidyNet">
       <HintPath>..\..\src\packages\UmbracoCms.Core.6.2.5\lib\TidyNet.dll</HintPath>
     </Reference>
@@ -231,6 +232,9 @@
     <Compile Include="InheritedClassWithPrefixedPropertyTests.cs" />
     <Compile Include="JsonSerializationWithTypeConverterTests.cs" />
     <Compile Include="MockProcessorTests.cs" />
+    <Compile Include="Mocks\MockHttpContext.cs" />
+    <Compile Include="Mocks\MockPublishedContentCache.cs" />
+    <Compile Include="Mocks\MockPublishedMediaCache.cs" />
     <Compile Include="Models\ImageCropModels.cs" />
     <Compile Include="AppSettingsTests.cs" />
     <Compile Include="Mocks\PublishedContentMock.cs" />
@@ -245,6 +249,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SingularityMappingTests.cs" />
     <Compile Include="TypeInferenceTests.cs" />
+    <Compile Include="UmbracoPickerProcessorTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Our.Umbraco.Ditto\Our.Umbraco.Ditto.csproj">

--- a/tests/Our.Umbraco.Ditto.Tests/UmbracoPickerProcessorTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/UmbracoPickerProcessorTests.cs
@@ -1,0 +1,71 @@
+﻿using NUnit.Framework;
+using Our.Umbraco.Ditto.Tests.Mocks;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.ObjectResolution;
+using Umbraco.Web;
+using Umbraco.Web.PublishedCache;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    public class UmbracoPickerProcessorTests
+    {
+        public class MyModel<T>
+        {
+            [UmbracoProperty(Order = 1)]
+            [UmbracoPicker(Order = 2)]
+            public T MyProperty { get; set; }
+        }
+
+        public class MyTypedModel
+        {
+            public int Id { get; set; }
+        }
+
+        private IPublishedContent Content;
+
+        private int NodeId;
+
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            if (!PublishedCachesResolver.HasCurrent)
+                PublishedCachesResolver.Current =
+                    new PublishedCachesResolver(new PublishedCaches(new MockPublishedContentCache(), new MockPublishedMediaCache()));
+
+            UmbracoContext.EnsureContext(new MockHttpContext(), new ApplicationContext(new CacheHelper()), true);
+
+            Resolution.Freeze();
+
+            NodeId = 1234;
+
+            Content = new PublishedContentMock()
+            {
+                Properties = new[]
+                {
+                    new PublishedContentPropertyMock("myProperty", NodeId, true) }
+            };
+        }
+
+        [Test]
+        public void UmbracoPicker_Processes_PublishedContent()
+        {
+            var model = Content.As<MyModel<IPublishedContent>>();
+
+            Assert.That(model.MyProperty, Is.Not.Null);
+            Assert.IsInstanceOf<IPublishedContent>(model.MyProperty);
+            Assert.That(model.MyProperty.Id, Is.EqualTo(NodeId));
+        }
+
+        [Test]
+        public void UmbracoPicker_Processes_Typed()
+        {
+            var model = Content.As<MyModel<MyTypedModel>>();
+
+            Assert.That(model.MyProperty, Is.Not.Null);
+            Assert.IsInstanceOf<MyTypedModel>(model.MyProperty);
+            Assert.That(model.MyProperty.Id, Is.EqualTo(NodeId));
+        }
+    }
+}


### PR DESCRIPTION
Following a discussion with @mattbrailsford earlier today, I started to play with mocking the UmbracoContext in order to test the UmbracoPicker processor.

So far I have manually mocked things like HttpContextBase and the PublishedContent/MediaCache objects - we may find that a mocking library (such as Moq) would be better, but I have limited knowledge on that... (totally open to advice on that!)

The interesting part about testing UmbracoPicker is that we can remove the subsequent `.As(targetType)` calls, as when a processor returns an `IPublishedContent` object, it will automagically check the target type and process further.

---

I've opened as a pull-request to gauge feedback on the mocking approach... and to check that @JimBobSquarePants is happy with the `.As(targetType)` removal :smile: 