### PR TITLE
Fix #179

### DIFF
--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -466,12 +466,23 @@ namespace Our.Umbraco.Ditto
             if (!processorAttrs.Any())
             {
                 // Adds the default processor attribute
-                processorAttrs.Add((DittoProcessorAttribute)defaultProcessorType.GetInstance());
+                processorAttrs.Insert(0, (DittoProcessorAttribute)defaultProcessorType.GetInstance());
             }
 
             // Check for type registered processors
             processorAttrs.AddRange(propertyInfo.PropertyType.GetCustomAttributes<DittoProcessorAttribute>(true)
-                .OrderBy(x => x.Order));
+                    .OrderBy(x => x.Order));
+
+            // Check any type arguments in generic enumerable types.
+            // This should return false against typeof(string) etc also.
+            var propertyType = propertyInfo.PropertyType;
+            var typeInfo = propertyType.GetTypeInfo();
+            if (propertyType.IsCastableEnumerableType())
+            {
+                processorAttrs.AddRange(typeInfo.GenericTypeArguments.First().GetCustomAttributes<DittoProcessorAttribute>(true)
+                    .OrderBy(x => x.Order)
+                    .ToList());
+            }
 
             // Check for globally registered processors
             processorAttrs.AddRange(DittoProcessorRegistry.Instance.GetRegisteredProcessorAttributesFor(propertyInfo.PropertyType));

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -466,7 +466,7 @@ namespace Our.Umbraco.Ditto
             if (!processorAttrs.Any())
             {
                 // Adds the default processor attribute
-                processorAttrs.Insert(0, (DittoProcessorAttribute)defaultProcessorType.GetInstance());
+                processorAttrs.Add((DittoProcessorAttribute)defaultProcessorType.GetInstance());
             }
 
             // Check for type registered processors


### PR DESCRIPTION
Adds the ability to track attributes on typeparams in generic types.
This matches behaviour in pre 0.9.0 releases.