### PR TITLE
Adds PropertySource to UmbracoPropertyAttribute 

### DIFF
--- a/src/Our.Umbraco.Ditto/Common/DittoDisposableTimer.cs
+++ b/src/Our.Umbraco.Ditto/Common/DittoDisposableTimer.cs
@@ -22,9 +22,9 @@ namespace Our.Umbraco.Ditto
         /// <typeparam name="T">The type of the calling class.</typeparam>
         /// <param name="startMessage">The starting message for the profiler.</param>
         /// <returns>Returns an instance of the disposable timer.</returns>
-        public static new DisposableTimer DebugDuration<T>(string startMessage)
+        public new static DisposableTimer DebugDuration<T>(string startMessage)
         {
-            if (Ditto.IsDebuggingEnabled)
+            if (Ditto.IsDebuggingEnabled && ApplicationContext.Current != null && ApplicationContext.Current.ProfilingLogger != null)
             {
                 return ApplicationContext.Current.ProfilingLogger.DebugDuration<T>(startMessage);
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertiesAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertiesAttribute.cs
@@ -9,6 +9,14 @@ namespace Our.Umbraco.Ditto
     public class UmbracoPropertiesAttribute : Attribute
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoPropertiesAttribute"/> class.
+        /// </summary>
+        public UmbracoPropertiesAttribute()
+        {
+            PropertySource = Ditto.DefaultPropertySource;
+        }
+
+        /// <summary>
         /// Gets or sets the prefix.
         /// </summary>
         public string Prefix { get; set; }
@@ -20,5 +28,10 @@ namespace Our.Umbraco.Ditto
         ///   <c>true</c> if [recursive]; otherwise, <c>false</c>.
         /// </value>
         public bool Recursive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property source from which to map values from
+        /// </summary>
+        public PropertySource PropertySource { get; set; }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
@@ -109,6 +109,16 @@ namespace Our.Umbraco.Ditto
 
                     // Apply global recursive setting
                     recursive |= classAttr.Recursive;
+
+                    // Apply property source only if it's different from the default,
+                    // and the current value is the default. We only do it this
+                    // way because if they change it at the property level, we 
+                    // want that to take precedence over the class level.
+                    if (classAttr.PropertySource != Ditto.DefaultPropertySource
+                        && PropertySource == Ditto.DefaultPropertySource)
+                    {
+                        PropertySource = classAttr.PropertySource;
+                    }
                 }
             }
 

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -25,7 +25,12 @@ namespace Our.Umbraco.Ditto
         /// <summary>
         /// The default processor cache by flags
         /// </summary>
-        public const DittoCacheBy DefaultCacheBy = DittoCacheBy.ContentId | DittoCacheBy.ContentVersion | DittoCacheBy.PropertyName | DittoCacheBy.Culture;
+        public static DittoCacheBy DefaultCacheBy = DittoCacheBy.ContentId | DittoCacheBy.ContentVersion | DittoCacheBy.PropertyName | DittoCacheBy.Culture;
+
+        /// <summary>
+        /// The default source for umbraco property mappings
+        /// </summary>
+        public static PropertySource DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
 
         /// <summary>
         /// The property bindings for mappable properties

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration;
+using System.Linq;
+using System.Reflection;
 using System.Web;
 using System.Web.Configuration;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 
 namespace Our.Umbraco.Ditto
 {
@@ -21,6 +26,18 @@ namespace Our.Umbraco.Ditto
         /// The default processor cache by flags
         /// </summary>
         public const DittoCacheBy DefaultCacheBy = DittoCacheBy.ContentId | DittoCacheBy.ContentVersion | DittoCacheBy.PropertyName | DittoCacheBy.Culture;
+
+        /// <summary>
+        /// The property bindings for mappable properties
+        /// </summary>
+        internal const BindingFlags MappablePropertiesBindingFlags = BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static;
+
+        /// <summary>
+        /// A list of mappable properties defined on the IPublishedContent interface
+        /// </summary>
+        internal static readonly IEnumerable<PropertyInfo> IPublishedContentProperties = typeof(IPublishedContent).GetProperties(MappablePropertiesBindingFlags)
+            .Where(x => x.IsMappable())
+            .ToList();
 
         /// <summary>
         /// Gets a value indicating whether application is running in debug mode.

--- a/tests/Our.Umbraco.Ditto.Tests/BasicMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/BasicMappingTests.cs
@@ -43,11 +43,6 @@ namespace Our.Umbraco.Ditto.Tests
             public string Item { get; set; }
         }
 
-        public class BasicModelWithChildrenProperty
-        {
-            public string Children { get; set; }
-        }
-
         [Test]
         public void Basic_Name_IsMapped()
         {
@@ -122,42 +117,6 @@ namespace Our.Umbraco.Ditto.Tests
             var model = content.As<BasicModelWithItemProperty>();
 
             Assert.That(model.Item, Is.EqualTo(value));
-        }
-
-        [Test]
-        public void Basic_Content_Reserved_Property_Warns()
-        {
-            ConfigurationManager.AppSettings["Ditto:DebugEnabled"] = "true";
-
-            // Create a mock logger
-            var mockLogger = new MockLogger();
-            if (ResolverBase<LoggerResolver>.HasCurrent)
-            {
-                ResolverBase<LoggerResolver>.Current.SetLogger(mockLogger);
-            }
-            else
-            {
-                ResolverBase<LoggerResolver>.Current = new LoggerResolver(mockLogger) { CanResolveBeforeFrozen = true };
-            }
-
-            // Create a hidden mapping
-            var value = "myValue";
-            var content = new MockPublishedContent
-            {
-                Properties = new[] { new MockPublishedContentProperty("children", value) }
-            };
-
-            // Perform the conversion
-            var model = content.As<BasicModelWithChildrenProperty>();
-
-            // Ensure a warning message was logged
-            var logMessages = mockLogger.GetLogMessages().Where(x => x.MessageType == LogMessageType.Warn && x.CallingType == typeof(UmbracoPropertyAttribute));
-
-            // Turn debugging back off (can effect other tests if left enabled)
-            ConfigurationManager.AppSettings["Ditto:DebugEnabled"] = "false";
-
-            Assert.NotNull(logMessages);
-            Assert.That(logMessages.Any(x => x.Message.Contains("hides")));
         }
 
         [Test]

--- a/tests/Our.Umbraco.Ditto.Tests/Mocks/MockLogger.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Mocks/MockLogger.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core.Logging;
+
+namespace Our.Umbraco.Ditto.Tests.Mocks
+{
+    internal class MockLogger : ILogger
+    {
+        private readonly List<LogMessage> logMessages;
+
+        public MockLogger()
+        {
+            this.logMessages = new List<LogMessage>();
+        } 
+
+        public void Error(Type callingType, string message, Exception exception)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Error, CallingType = callingType, Message = message, Exception = exception });
+        }
+
+        public void Warn(Type callingType, string message, params Func<object>[] formatItems)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Warn, CallingType = callingType, Message = string.Format(message, formatItems.Select(x => x.Invoke()).ToArray()) });
+        }
+
+        public void WarnWithException(Type callingType, string message, Exception e, params Func<object>[] formatItems)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Warn, CallingType = callingType, Message = string.Format(message, formatItems.Select(x => x.Invoke()).ToArray()), Exception = e });
+        }
+
+        public void Info(Type callingType, Func<string> generateMessage)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Info, CallingType = callingType, Message = generateMessage.Invoke() });
+        }
+
+        public void Info(Type callingType, string generateMessageFormat, params Func<object>[] formatItems)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Info, CallingType = callingType, Message = string.Format(generateMessageFormat, formatItems.Select(x => x.Invoke()).ToArray()) });
+        }
+
+        public void Debug(Type callingType, Func<string> generateMessage)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Debug, CallingType = callingType, Message = generateMessage.Invoke() });
+        }
+
+        public void Debug(Type callingType, string generateMessageFormat, params Func<object>[] formatItems)
+        {
+            logMessages.Add(new LogMessage { MessageType = LogMessageType.Info, CallingType = callingType, Message = string.Format(generateMessageFormat, formatItems.Select(x => x.Invoke()).ToArray()) });
+        }
+
+        public IEnumerable<LogMessage> GetLogMessages()
+        {
+            return this.logMessages;
+        }
+    }
+
+    internal class LogMessage
+    {
+        public Type CallingType { get; set; }
+
+        public LogMessageType MessageType { get; set; }
+
+        public string Message { get; set; }
+
+        public Exception Exception { get; set; } 
+    }
+
+    internal enum LogMessageType
+    {
+        Error,
+        Warn,
+        Info,
+        Debug
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Mocks/MockLogger.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Mocks/MockLogger.cs
@@ -53,6 +53,11 @@ namespace Our.Umbraco.Ditto.Tests.Mocks
         {
             return this.logMessages;
         }
+
+        public void ClearLogMessages()
+        {
+            this.logMessages.Clear();
+        }
     }
 
     internal class LogMessage

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="IgnoreAttributeTests.cs" />
     <Compile Include="ImageCropDataSetMappingTests.cs" />
     <Compile Include="InheritedClassWithPrefixedPropertyTests.cs" />
+    <Compile Include="Mocks\MockLogger.cs" />
     <Compile Include="SetMethodTests.cs" />
     <Compile Include="JsonSerializationWithTypeConverterTests.cs" />
     <Compile Include="MockProcessorTests.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -96,6 +96,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="PropertySourceMappingTests.cs" />
     <Compile Include="DittoFactoryTests.cs" />
     <Compile Include="DictionaryValueTests.cs" />
     <Compile Include="CreateDateTests.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
@@ -71,6 +71,9 @@ namespace Our.Umbraco.Ditto.Tests
             Assert.AreEqual(custonName, model.Name);
             Assert.IsNull(model.Url);
             Assert.AreEqual(custonProp, model.Custom);
+
+            // Reset
+            Ditto.DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
         }
 
         [Test]
@@ -128,7 +131,8 @@ namespace Our.Umbraco.Ditto.Tests
             Assert.NotNull(logMessages);
             Assert.That(logMessages.Any(x => x.Message.Contains("hides an instance property")));
 
-            // Turn debugging back off (can effect other tests if left enabled)
+            // Reset
+            Ditto.DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
             ConfigurationManager.AppSettings["Ditto:DebugEnabled"] = "false";
         }
     }

--- a/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Configuration;
+using System.Linq;
+using System.Web;
+using Moq;
+using NUnit.Framework;
+using Our.Umbraco.Ditto.Tests.Mocks;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.ObjectResolution;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    [Category("Mapping")]
+    public class PropertySourceMappingTests
+    {
+        public class BasicModelProperty
+        {
+            public string Name { get; set; }
+
+            public string Url { get; set; }
+
+            public string Custom { get; set; }
+        }
+
+        [Test]
+        public void PropertySource_Instance_Then_Umbraco_Maps()
+        {
+            var instanceName = "Instance Name";
+            var instanceUrl = "/instance/url";
+            var custonName = "Custom Name";
+            var custonProp = "Custom Prop";
+
+            // Create a hidden mapping
+            var content = new MockPublishedContent
+            {
+                Name = instanceName,
+                Url = instanceUrl,
+                Properties = new[]
+                {
+                    new MockPublishedContentProperty("name", custonName),
+                    new MockPublishedContentProperty("custom", custonProp)
+                }
+            };
+
+            Ditto.DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
+
+            var model = content.As<BasicModelProperty>();
+            Assert.AreEqual(instanceName, model.Name);
+            Assert.AreEqual(instanceUrl, model.Url);
+            Assert.AreEqual(custonProp, model.Custom);
+
+            Ditto.DefaultPropertySource = PropertySource.UmbracoThenInstanceProperties;
+
+            model = content.As<BasicModelProperty>();
+            Assert.AreEqual(custonName, model.Name);
+            Assert.AreEqual(instanceUrl, model.Url);
+            Assert.AreEqual(custonProp, model.Custom);
+
+            Ditto.DefaultPropertySource = PropertySource.InstanceProperties;
+
+            model = content.As<BasicModelProperty>();
+            Assert.AreEqual(instanceName, model.Name);
+            Assert.AreEqual(instanceUrl, model.Url);
+            Assert.IsNull(model.Custom);
+
+            Ditto.DefaultPropertySource = PropertySource.UmbracoProperties;
+
+            model = content.As<BasicModelProperty>();
+            Assert.AreEqual(custonName, model.Name);
+            Assert.IsNull(model.Url);
+            Assert.AreEqual(custonProp, model.Custom);
+        }
+
+        [Test]
+        public void PropertySource_Hidden_Properties_Warn()
+        {
+            ConfigurationManager.AppSettings["Ditto:DebugEnabled"] = "true";
+
+            // Create a mock logger
+            var mockLogger = new MockLogger();
+            if (ResolverBase<LoggerResolver>.HasCurrent)
+            {
+                ResolverBase<LoggerResolver>.Current.SetLogger(mockLogger);
+            }
+            else
+            {
+                ResolverBase<LoggerResolver>.Current = new LoggerResolver(mockLogger) { CanResolveBeforeFrozen = true };
+            }
+
+            // Create a hidden mapping
+            var instanceName = "Instance Name";
+            var instanceUrl = "/instance/url";
+            var custonName = "Custom Name";
+            var custonProp = "Custom Prop";
+
+            var content = new MockPublishedContent
+            {
+                Name = instanceName,
+                Url = instanceUrl,
+                Properties = new[]
+                {
+                    new MockPublishedContentProperty("name", custonName),
+                    new MockPublishedContentProperty("custom", custonProp)
+                }
+            };
+
+            // Check for hidden umbraco properties
+            Ditto.DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
+            
+            var model = content.As<BasicModelProperty>();
+            
+            var logMessages = mockLogger.GetLogMessages().Where(x => x.MessageType == LogMessageType.Warn && x.CallingType == typeof(UmbracoPropertyAttribute));
+
+            Assert.NotNull(logMessages);
+            Assert.That(logMessages.Any(x => x.Message.Contains("hides a property in the umbraco properties collection")));
+
+            // Check for hidden instance properties
+            mockLogger.ClearLogMessages();
+
+            Ditto.DefaultPropertySource = PropertySource.UmbracoThenInstanceProperties;
+
+            model = content.As<BasicModelProperty>();
+
+            logMessages = mockLogger.GetLogMessages().Where(x => x.MessageType == LogMessageType.Warn && x.CallingType == typeof(UmbracoPropertyAttribute));
+
+            Assert.NotNull(logMessages);
+            Assert.That(logMessages.Any(x => x.Message.Contains("hides an instance property")));
+
+            // Turn debugging back off (can effect other tests if left enabled)
+            ConfigurationManager.AppSettings["Ditto:DebugEnabled"] = "false";
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
@@ -25,7 +25,7 @@ namespace Our.Umbraco.Ditto.Tests
         }
 
         [Test]
-        public void PropertySource_Instance_Then_Umbraco_Maps()
+        public void PropertySource_Properties_Map()
         {
             var instanceName = "Instance Name";
             var instanceUrl = "/instance/url";

--- a/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/PropertySourceMappingTests.cs
@@ -24,6 +24,17 @@ namespace Our.Umbraco.Ditto.Tests
             public string Custom { get; set; }
         }
 
+        [UmbracoProperties(PropertySource = PropertySource.UmbracoThenInstanceProperties)]
+        public class BasicModelProperty2
+        {
+            public string Name { get; set; }
+
+            [UmbracoProperty(PropertySource = PropertySource.InstanceThenUmbracoProperties)]
+            public string Url { get; set; }
+
+            public string Custom { get; set; }
+        }
+
         [Test]
         public void PropertySource_Properties_Map()
         {
@@ -74,6 +85,33 @@ namespace Our.Umbraco.Ditto.Tests
 
             // Reset
             Ditto.DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
+        }
+
+        [Test]
+        public void PropertySource_Attributed_Properties_Map()
+        {
+            var instanceName = "Instance Name";
+            var instanceUrl = "/instance/url";
+            var custonName = "Custom Name";
+            var custonProp = "Custom Prop";
+
+            // Create a hidden mapping
+            var content = new MockPublishedContent
+            {
+                Name = instanceName,
+                Url = instanceUrl,
+                Properties = new[]
+                {
+                    new MockPublishedContentProperty("name", custonName),
+                    new MockPublishedContentProperty("custom", custonProp)
+                }
+            };
+
+            var model = content.As<BasicModelProperty2>();
+
+            Assert.AreEqual(custonName, model.Name);
+            Assert.AreEqual(instanceUrl, model.Url);
+            Assert.AreEqual(custonProp, model.Custom);
         }
 
         [Test]


### PR DESCRIPTION
This is a fix for issue #184. 

Added code to allow you to select a property source when using UmbracoPropertyAttribute so that you can define the order in which properties are checked between the instance properties and properties in the umbraco properties collection. This can be set per property using the PropertySource parameter of the UmbracoPropertyAttribute, or globally by setting Ditto.DefaultPropertySource in an app startup handler. If using either InstanceThenUmbracoProperties (the default) or UmbracoThenInstanceProperties and the site is in debug mode, and ditto detects that the property requested hides a property in the other source, then a warning log message will be logged to the log file giving instructions to either not use reserved aliases, or to use PropertySource to override the behavior if required.