### PR TITLE
Adding an empty constructor to DittoMultiProcessorAttribute

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoMultiProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoMultiProcessorAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Our.Umbraco.Ditto
 {
@@ -17,6 +18,13 @@ namespace Our.Umbraco.Ditto
         protected DittoMultiProcessorAttribute(IEnumerable<DittoProcessorAttribute> attributes)
         {
             this.Attributes = new List<DittoProcessorAttribute>(attributes);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoMultiProcessorAttribute" /> class.
+        /// </summary>
+        protected DittoMultiProcessorAttribute() : this(Enumerable.Empty<DittoProcessorAttribute>())
+        {
         }
 
         /// <summary>

--- a/tests/Our.Umbraco.Ditto.Tests/MultiProcessorTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/MultiProcessorTests.cs
@@ -14,6 +14,13 @@ namespace Our.Umbraco.Ditto.Tests
                 MyCustomProcessor3(Order = 3)]
             public string MyProperty { get; set; }
         }
+        public class MyModel2
+        {
+            [UmbracoProperty("Name", Order = 1),
+                MyEmptyBaseConstructorMultiProcessor(Order = 2),
+                MyCustomProcessor3(Order = 3)]
+            public string MyProperty { get; set; }
+        }
 
         public class MyMultiProcessorAttribute : DittoMultiProcessorAttribute
         {
@@ -25,6 +32,21 @@ namespace Our.Umbraco.Ditto.Tests
                       new MyCustomProcessor3Attribute()
                 })
             { }
+        }
+
+
+        public class MyEmptyBaseConstructorMultiProcessorAttribute : DittoMultiProcessorAttribute
+        {
+            public MyEmptyBaseConstructorMultiProcessorAttribute()
+            {
+                base.Attributes.AddRange(
+                    new DittoProcessorAttribute[]
+                    {
+                        new MyCustomProcessor1Attribute(),
+                        new MyCustomProcessor2Attribute(),
+                        new MyCustomProcessor3Attribute()
+                    });
+            }
         }
 
         public class MyCustomProcessor1Attribute : DittoProcessorAttribute
@@ -82,6 +104,33 @@ namespace Our.Umbraco.Ditto.Tests
 
             Assert.That(model.MyProperty, Is.Not.Null);
             Assert.That(model.MyProperty, Is.EqualTo("MyNameTest1Test2Test3Test3"));
+        }
+
+
+        [Test]
+        public void MultiProcessor_EmptyConstructor_Test()
+        {
+            // In this test, the `MyProperty` property gets a `string` value
+            // via the `UmbracoProperty`. The `string` type/value is passed
+            // to the `MyCustomConverter` so to convert the `string` to a
+            // `MyCustomModel` type/object.
+
+            // Then a second class which uses the `MyModel2` and the `MyEmptyBaseConstructorMultiProcessorAttribute` calling similar code.
+            // It then asserts that the output of `MyProperty` for `MyModel` is equal to thw value of `MyProperty` of `MyModel2`.
+
+            var content = new MockPublishedContent() { Name = "MyName" };
+            var model = content.As<MyModel>();
+            var model2 = content.As<MyModel2>();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model, Is.InstanceOf<MyModel>());
+
+            Assert.That(model2, Is.Not.Null);
+            Assert.That(model2, Is.InstanceOf<MyModel2>());
+
+            Assert.That(model.MyProperty, Is.Not.Null);
+            Assert.That(model2.MyProperty, Is.Not.Null);
+            Assert.That(model.MyProperty, Is.EqualTo(model2.MyProperty));
         }
     }
 }


### PR DESCRIPTION
During Code Cabin 16 (woo #codecabin16!) @mattbrailsford asked us to remind him to add an empty constructor to DittoMultiProcessorAttribute. Instead I've added in the code myself (feature sniping! :/)

The reason for this was to allow more sophisticated parameter/property binding through the inherited DittoMultiProcessorAttribute.

Example of this would be the following.

```csharp
    public class TitleAttribute : DittoMultiProcessorAttribute
    {
        public string TitlePropertyAlias { get; set; }

        public TitleAttribute()
        {
            base.Attributes.AddRange(new[]
            {
                new UmbracoPropertyAttribute(TitlePropertyAlias),
                new AltUmbracoPropertyAttribute("Name")
            });
        }
    }
```

Where as the traditional way to achieve a similar thing would be:

```csharp
    public class TitleAttribute : DittoMultiProcessorAttribute
    {
        public TitleAttribute(string titlePropertyAlias) : base(new[]
        {
            new UmbracoPropertyAttribute(titlePropertyAlias),
            new AltUmbracoPropertyAttribute("Name")
        })
        {
            
        }
    }
```

This is a fairly simple example but there could be better uses with this new flexibility. I've also added in a unit test to prove out the results of a traditional DittoMultiProcessorAttribute is the same as the new empty constructor DittoMultiProcessorAttribute.