### PR TITLE
Proxy class properties accessing object instance properties

### DIFF
--- a/tests/Our.Umbraco.Ditto.Tests/Issue177Tests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Issue177Tests.cs
@@ -1,0 +1,81 @@
+using NUnit.Framework;
+using Our.Umbraco.Ditto.Tests.Mocks;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    /// <remarks>
+    /// Unit-test to verify an issue - as outlined in #177
+    /// https://github.com/leekelleher/umbraco-ditto/issues/177
+    /// When a property is marked as `virtual`, it becomes lazy-loaded,
+    /// and not accessible by other properties on the model.
+    /// </remarks>
+    [TestFixture]
+    public class Issue177Tests
+    {
+        interface IInterface1
+        {
+            int IdInt { get; set; }
+        }
+
+        interface IInterface2
+        {
+            string IdString { get; }
+        }
+
+        public abstract class Base : IInterface1, IInterface2
+        {
+            public virtual string IdString
+            {
+                get
+                {
+                    return IdInt.ToString();
+                }
+            }
+
+            public virtual int IdInt
+            {
+                get;
+                set;
+            }
+        }
+
+        public class NewClass : Base
+        {
+            public override string IdString
+            {
+                get
+                {
+                    return IdInt.ToString();
+                }
+            }
+
+            [UmbracoProperty("ItemLink")]
+            public override int IdInt
+            {
+                get;
+                set;
+            }
+        }
+
+        [Test]
+        public void Issue177_Test()
+        {
+            var nodeId = 1613;
+
+            var content = new MockPublishedContent
+            {
+                Properties = new[]
+                {
+                    new MockPublishedContentProperty("ItemLink", nodeId)
+                }
+            };
+
+            var model = content.As<NewClass>();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model.IdInt, Is.EqualTo(nodeId));
+
+            Assert.That(model.IdString, Is.EqualTo(nodeId.ToString()));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="ImageCropDataSetMappingTests.cs" />
     <Compile Include="InheritedClassWithPrefixedPropertyTests.cs" />
     <Compile Include="Mocks\MockLogger.cs" />
+    <Compile Include="Issue177Tests.cs" />
     <Compile Include="SetMethodTests.cs" />
     <Compile Include="JsonSerializationWithTypeConverterTests.cs" />
     <Compile Include="MockProcessorTests.cs" />


### PR DESCRIPTION
Added failing unit-test for issue #177

When using proxy classes, it appears that lazy-loaded properties can not access the property values of its object instance.

@JimBobSquarePants to review (in due course - no rush, just wanted to keep track of this) :sunglasses: 
