### PR TITLE
DittoLazy attribute

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoLazyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoLazyAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Our.Umbraco.Ditto.ComponentModel.Attributes
+{
+    /// <summary>
+    /// The Ditto lazy property attribute.
+    /// Used for specifying that Ditto should lazy load this property.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class DittoLazyAttribute : Attribute
+    { }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoLazyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoLazyAttribute.cs
@@ -6,7 +6,7 @@ namespace Our.Umbraco.Ditto.ComponentModel.Attributes
     /// The Ditto lazy property attribute.
     /// Used for specifying that Ditto should lazy load this property.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false)]
     public class DittoLazyAttribute : Attribute
     { }
 }

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -34,7 +34,7 @@ namespace Our.Umbraco.Ditto
         /// <summary>
         /// The default lazy load strategy
         /// </summary>
-        public static LazyLoad LazyLoad = LazyLoad.AttributedVirtuals;
+        public static LazyLoad LazyLoadStrategy = LazyLoad.AttributedVirtuals;
 
         /// <summary>
         /// The property bindings for mappable properties

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -32,6 +32,11 @@ namespace Our.Umbraco.Ditto
         public static PropertySource DefaultPropertySource = PropertySource.InstanceThenUmbracoProperties;
 
         /// <summary>
+        /// The default lazy load strategy
+        /// </summary>
+        public static LazyLoad LazyLoad = LazyLoad.AttributedVirtuals;
+
+        /// <summary>
         /// The property bindings for mappable properties
         /// </summary>
         internal const BindingFlags MappablePropertiesBindingFlags = BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Static;

--- a/src/Our.Umbraco.Ditto/Extensions/Internal/MemberInfoExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/Internal/MemberInfoExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// Extensions methods for <see cref="MemberInfo"/>.
+    /// </summary>
+    internal static class MemberInfoExtensions
+    {
+        /// <summary>
+        /// Checks to see if the member has the specified attribute
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="element"></param>
+        /// <returns></returns>
+        public static bool HasCustomAttribute<T>(this MemberInfo element) where T : Attribute
+        {
+            return element.GetCustomAttribute<T>() != null;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Extensions/Internal/PropertyInfoExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/Internal/PropertyInfoExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Our.Umbraco.Ditto.ComponentModel.Attributes;
 
 namespace Our.Umbraco.Ditto
 {
@@ -57,6 +58,18 @@ namespace Our.Umbraco.Ditto
 
             // All checks have passed so allow it to be mapped
             return true;
+        }
+
+        /// <summary>
+        /// Checks to see if the given poperty should attempt to lazy load
+        /// </summary>
+        /// <param name="source">The property to check</param>
+        /// <returns>True if a lazy load attempt should be make</returns>
+        public static bool ShouldAttemptLazyLoad(this PropertyInfo source)
+        {
+            return source.HasCustomAttribute<DittoLazyAttribute>() || 
+                ((source.DeclaringType.HasCustomAttribute<DittoLazyAttribute>() || Ditto.LazyLoadStrategy == LazyLoad.AllVirtuals) 
+                    && source.IsVirtualAndOverridable());
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -334,7 +334,7 @@ namespace Our.Umbraco.Ditto
                     var lazyAttr = propertyInfo.GetCustomAttribute<DittoLazyAttribute>();
                     if (lazyAttr != null)
                     { 
-                        // Configure lazy property
+                        // Configure lazy properties
                         using (DittoDisposableTimer.DebugDuration<object>(string.Format("ForEach Lazy Property ({1} {0})", propertyInfo.Name, content.Id)))
                         {
                             if (!propertyInfo.IsVirtualAndOverridable())

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -326,9 +326,6 @@ namespace Our.Umbraco.Ditto
             // A dictionary to store lazily invoked values.
             var lazyProperties = new Dictionary<string, Lazy<object>>();
 
-            // See if the type is marked as lazy
-            var typeLazyAttr = type.GetCustomAttribute<DittoLazyAttribute>();
-
             // Process all the properties.
             if (properties.Any())
             {

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -357,6 +357,7 @@ namespace Our.Umbraco.Ditto
                             var deferredPropertyInfo = propertyInfo;
                             var localInstance = instance;
 
+                            // ReSharper disable once PossibleMultipleEnumeration
                             lazyProperties.Add(propertyInfo.Name, new Lazy<object>(() => GetProcessedValue(content, culture, type, deferredPropertyInfo, localInstance, defaultProcessorType, processorContexts)));
                         }
                     }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -335,7 +335,7 @@ namespace Our.Umbraco.Ditto
                 foreach (var propertyInfo in properties)
                 {
                     var propLazyAttr = propertyInfo.GetCustomAttribute<DittoLazyAttribute>();
-                    if (propLazyAttr != null || ((typeLazyAttr != null || Ditto.LazyLoad == LazyLoad.AllVirtuals) && propertyInfo.IsVirtualAndOverridable()))
+                    if (propLazyAttr != null || ((typeLazyAttr != null || Ditto.LazyLoadStrategy == LazyLoad.AllVirtuals) && propertyInfo.IsVirtualAndOverridable()))
                     { 
                         // Configure lazy properties
                         using (DittoDisposableTimer.DebugDuration<object>(string.Format("ForEach Lazy Property ({1} {0})", propertyInfo.Name, content.Id)))

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -345,8 +345,7 @@ namespace Our.Umbraco.Ditto
                         }
 
                         // Check for the ignore attribute (Only relevant to class level lazy loads).
-                        var ignoreAttr = propertyInfo.GetCustomAttribute<DittoIgnoreAttribute>();
-                        if (ignoreAttr != null)
+                        if (propertyInfo.HasCustomAttribute<DittoIgnoreAttribute>())
                         {
                             continue;
                         }
@@ -378,8 +377,7 @@ namespace Our.Umbraco.Ditto
                     using (DittoDisposableTimer.DebugDuration<object>(string.Format("ForEach Property ({1} {0})", propertyInfo.Name, content.Id)))
                     {
                         // Check for the ignore attribute.
-                        var ignoreAttr = propertyInfo.GetCustomAttribute<DittoIgnoreAttribute>();
-                        if (ignoreAttr != null)
+                        if (propertyInfo.HasCustomAttribute<DittoIgnoreAttribute>())
                         {
                             continue;
                         }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -335,7 +335,7 @@ namespace Our.Umbraco.Ditto
                 foreach (var propertyInfo in properties)
                 {
                     var propLazyAttr = propertyInfo.GetCustomAttribute<DittoLazyAttribute>();
-                    if (propLazyAttr != null || (typeLazyAttr != null && propertyInfo.IsVirtualAndOverridable()))
+                    if (propLazyAttr != null || ((typeLazyAttr != null || Ditto.LazyLoad == LazyLoad.AllVirtuals) && propertyInfo.IsVirtualAndOverridable()))
                     { 
                         // Configure lazy properties
                         using (DittoDisposableTimer.DebugDuration<object>(string.Format("ForEach Lazy Property ({1} {0})", propertyInfo.Name, content.Id)))

--- a/src/Our.Umbraco.Ditto/LazyLoad.cs
+++ b/src/Our.Umbraco.Ditto/LazyLoad.cs
@@ -1,0 +1,18 @@
+﻿namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// Enum to describe when properties should be lazy loaded during a ditto conversion
+    /// </summary>
+    public enum LazyLoad
+    {
+        /// <summary>
+        /// Make all virtual properties lazy
+        /// </summary>
+        AllVirtuals,
+
+        /// <summary>
+        /// Only make attributed virtual properties lazy
+        /// </summary>
+        AttributedVirtuals
+    }
+}

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Common\CachedInvocations.cs" />
     <Compile Include="Common\PropertyInfoInvocations.cs" />
     <Compile Include="ComponentModel\Attributes\DittoDefaultProcessorAttribute.cs" />
+    <Compile Include="ComponentModel\Attributes\DittoLazyAttribute.cs" />
     <Compile Include="ComponentModel\Caching\DittoCacheContext.cs" />
     <Compile Include="ComponentModel\Attributes\DittoCacheableAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoCacheAttribute.cs" />

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Extensions\Internal\TypeInitializationExtensions.cs" />
     <Compile Include="Extensions\RenderModelExtensions.cs" />
     <Compile Include="Extensions\PublishedContentExtensions.cs" />
+    <Compile Include="LazyLoad.cs" />
     <Compile Include="Models\DittoTransferModel.cs" />
     <Compile Include="Models\DittoViewModel.cs" />
     <Compile Include="Models\IDittoViewModel.cs" />

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -120,6 +120,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Ditto.cs" />
+    <Compile Include="Extensions\Internal\MemberInfoExtensions.cs" />
     <Compile Include="Extensions\Internal\ObjectExtensions.cs" />
     <Compile Include="Extensions\Internal\EnumerableExtensions.cs" />
     <Compile Include="Extensions\Internal\PropertyInfoExtensions.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/LazyTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/LazyTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Our.Umbraco.Ditto.ComponentModel.Attributes;
+using Our.Umbraco.Ditto.Tests.Mocks;
+using Umbraco.Core.Models;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    [Category("Mapping")]
+    public class LazyTests
+    {
+        public class LazyModel0
+        {
+            [DittoLazy] // Should error
+            public string Name { get; set; }
+
+            public int Number { get; set; }
+        }
+
+        public class LazyModel1
+        {
+            [DittoLazy]
+            public virtual string Name { get; set; }
+
+            public int Number { get; set; }
+        }
+
+        [DittoLazy]
+        public class LazyModel2
+        {
+            public virtual string Name { get; set; }
+
+            public int Number { get; set; }
+        }
+
+        public class LazyModel4 // Will test using Ditto.LazyLoadStrategy
+        {
+            public virtual string Name { get; set; }
+
+            public int Number { get; set; }
+        }
+
+        private string name = "MyName";
+        private int number = 10;
+        private IPublishedContent mockContent;
+
+        [SetUp]
+        public void Setup()
+        {
+            mockContent = new MockPublishedContent
+            {
+                Name = name,
+                Properties = new List<IPublishedProperty>
+                {
+                    new MockPublishedContentProperty("number", number)
+                }
+            };
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void Non_Virtual_Lazy_Should_Throw()
+        {
+            var model = mockContent.As<LazyModel0>();
+        }
+
+        [Test]
+        public void Property_Level_Lazy_Should_Map()
+        {
+            var model = mockContent.As<LazyModel1>();
+            var proxy = model as IProxy;
+
+            Assert.IsNotNull(model);
+            Assert.IsNotNull(proxy);
+            Assert.That(model.Name, Is.EqualTo(name));
+            Assert.That(model.Number, Is.EqualTo(number));
+        }
+
+        [Test]
+        public void Class_Level_Lazy_Should_Map()
+        {
+            var model = mockContent.As<LazyModel2>();
+            var proxy = model as IProxy;
+
+            Assert.IsNotNull(model);
+            Assert.IsNotNull(proxy);
+            Assert.That(model.Name, Is.EqualTo(name));
+            Assert.That(model.Number, Is.EqualTo(number));
+        }
+
+        [Test]
+        public void Global_Level_Lazy_Should_Map()
+        {
+            Ditto.LazyLoadStrategy = LazyLoad.AllVirtuals;
+
+            var model = mockContent.As<LazyModel4>();
+            var proxy = model as IProxy;
+
+            Assert.IsNotNull(model);
+            Assert.IsNotNull(proxy);
+            Assert.That(model.Name, Is.EqualTo(name));
+            Assert.That(model.Number, Is.EqualTo(number));
+
+            Ditto.LazyLoadStrategy = LazyLoad.AttributedVirtuals;
+        }
+
+
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -96,6 +96,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="LazyTests.cs" />
     <Compile Include="PropertySourceMappingTests.cs" />
     <Compile Include="DittoFactoryTests.cs" />
     <Compile Include="DictionaryValueTests.cs" />


### PR DESCRIPTION
As discussed in #190, adding a DittoLazy attribute to be explicit about which properties are Lazy loaded.

@JimBobSquarePants can you check at line 385 that this is ok? In the original code, virtual props were made first, and this code ran, THEN non virtual property values were set. Should this be ok that all properties are set first lazy and non lazy, and THEN the proxy object is created?

Still need to do some unit tests