### PR TITLE
Multi processor context fixes

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoMultiProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoMultiProcessorAttribute.cs
@@ -30,6 +30,16 @@ namespace Our.Umbraco.Ditto
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="DittoMultiProcessorAttribute" /> class.
+        /// </summary>
+        /// <param name="attributes">The attributes.</param>
+        protected DittoMultiProcessorAttribute(params DittoProcessorAttribute[] attributes)
+            : this()
+        {
+            this.Attributes.AddRange(attributes);
+        }
+
+        /// <summary>
         /// Gets or sets the attributes.
         /// </summary>
         /// <value>
@@ -45,7 +55,7 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public override object ProcessValue()
         {
-            var ctx = (DittoMultiProcessorContext)this.Context;
+            var ctx = new DittoMultiProcessorContext(this.Context);
 
             foreach (var processorAttr in this.Attributes)
             {

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoMultiProcessorContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoMultiProcessorContext.cs
@@ -1,10 +1,26 @@
 ﻿namespace Our.Umbraco.Ditto
 {
     /// <summary>
-    /// Represents the context for a DittoMultiProcessorAttribute
+    ///     Represents the context for a DittoMultiProcessorAttribute
     /// </summary>
-    internal class DittoMultiProcessorContext : DittoProcessorContext
+    public class DittoMultiProcessorContext : DittoProcessorContext
     {
+        /// <summary>
+        /// Creates a new DittoMultiProcessorContext using an existing context
+        /// </summary>
+        /// <param name="context"></param>
+        public DittoMultiProcessorContext(DittoProcessorContext context) : base(context)
+        {
+            ContextCache = new DittoProcessorContextCache(Content, TargetType, PropertyDescriptor, Culture);
+        }
+
+        /// <summary>
+        /// Creates a new DittoMultiProcessorContext
+        /// </summary>
+        public DittoMultiProcessorContext()
+        {
+        }
+
         /// <summary>
         /// Gets or sets the context cache.
         /// </summary>

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoProcessorContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoProcessorContext.cs
@@ -63,5 +63,25 @@ namespace Our.Umbraco.Ditto
 
             return this;
         }
+
+        /// <summary>
+        /// Populates the core context fields using an existing context
+        /// </summary>
+        /// <param name="context">A context to duplicate</param>
+        public DittoProcessorContext(DittoProcessorContext context)
+        {
+            Culture = context.Culture;
+            TargetType = context.TargetType;
+            PropertyDescriptor = context.PropertyDescriptor;
+            Content = context.Content;
+        }
+
+        /// <summary>
+        /// Creates a new DittoProcessorContext
+        /// </summary>
+        public DittoProcessorContext()
+        {
+            
+        }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoProcessorContextCache.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoProcessorContextCache.cs
@@ -10,7 +10,7 @@ namespace Our.Umbraco.Ditto
     /// <summary>
     /// Represents a cache of processor contexts created during a single .As call
     /// </summary>
-    internal class DittoProcessorContextCache
+    public class DittoProcessorContextCache
     {
         /// <summary>
         /// The content


### PR DESCRIPTION
Added support for custom DittoMultiProcessorContexts

Previous attempts threw an invalid cast exception on [this line](https://github.com/leekelleher/umbraco-ditto/compare/develop...tompipe:MultiProcessorContextFixes?expand=1#diff-7f6541faf42ce058760b372fb7fa97a6L48)
