### PR TITLE
RecursiveDitto processor doesn't maintain the ProcessorContexts

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
@@ -118,12 +118,12 @@ namespace Our.Umbraco.Ditto
         /// <returns>
         /// Returns the post-processor attributes.
         /// </returns>
-        public IEnumerable<DittoProcessorAttribute> GetPostProcessorAttributes()
+        public IEnumerable<DittoProcessorAttribute> GetPostProcessorAttributes(IEnumerable<DittoProcessorContext> processorContexts = null)
         {
             // TODO: [LK] Enable the post-processor attributes to be configurable
             yield return new HtmlStringAttribute();
             yield return new EnumerableConverterAttribute();
-            yield return new RecursiveDittoAttribute();
+            yield return new RecursiveDittoAttribute() { ProcessorContexts = processorContexts };
             yield return new TryConvertToAttribute();
         }
 

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/RecursiveDittoAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/RecursiveDittoAttribute.cs
@@ -10,6 +10,11 @@ namespace Our.Umbraco.Ditto
     internal class RecursiveDittoAttribute : DittoProcessorAttribute
     {
         /// <summary>
+        /// Gets or sets the processor contexts.
+        /// </summary>
+        public IEnumerable<DittoProcessorContext> ProcessorContexts { get; set; }
+
+        /// <summary>
         /// Processes the value.
         /// </summary>
         /// <returns>
@@ -25,7 +30,11 @@ namespace Our.Umbraco.Ditto
                 if (this.Value is IPublishedContent && this.Context.PropertyDescriptor.PropertyType.IsClass)
                 {
                     // If the property value is an IPublishedContent, then we can use Ditto to map to the target type.
-                    result = ((IPublishedContent)this.Value).As(this.Context.PropertyDescriptor.PropertyType);
+                    result = ((IPublishedContent)this.Value).As(
+                        this.Context.PropertyDescriptor.PropertyType,
+                        this.Context.Culture,
+                        null,
+                        this.ProcessorContexts);
                 }
                 else if (this.Value != null && this.Value.GetType().IsEnumerableOfType(typeof(IPublishedContent))
                     && this.Context.PropertyDescriptor.PropertyType.IsEnumerable()
@@ -33,7 +42,10 @@ namespace Our.Umbraco.Ditto
                     && this.Context.PropertyDescriptor.PropertyType.GetEnumerableType().IsClass)
                 {
                     // If the property value is IEnumerable<IPublishedContent>, then we can use Ditto to map to the target type.
-                    result = ((IEnumerable<IPublishedContent>)this.Value).As(this.Context.PropertyDescriptor.PropertyType.GetEnumerableType());
+                    result = ((IEnumerable<IPublishedContent>)this.Value).As(
+                        this.Context.PropertyDescriptor.PropertyType.GetEnumerableType(),
+                        this.Context.Culture,
+                        this.ProcessorContexts);
                 }
             }
 

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -490,7 +490,7 @@ namespace Our.Umbraco.Ditto
             processorAttrs.AddRange(DittoProcessorRegistry.Instance.GetRegisteredProcessorAttributesFor(propertyInfo.PropertyType));
 
             // Add any core processors onto the end
-            processorAttrs.AddRange(DittoProcessorRegistry.Instance.GetPostProcessorAttributes());
+            processorAttrs.AddRange(DittoProcessorRegistry.Instance.GetPostProcessorAttributes(processorContexts));
 
             // Create holder for value as it's processed
             object currentValue = content;


### PR DESCRIPTION
If a processor returns an `IPublishedContent`, then the recursive processor (one of the default post-processors) will make an `.As()` call, but it doesn't pass in current `DittoProcessorContext` objects.  This pull-request aims to resolve this.

@mattbrailsford Are you happy with the processor contexts being passed through to `GetPostProcessorAttributes()`?