### PR TITLE
IUmbracoApplicationContextAccessor rename

### DIFF
--- a/src/Our.Umbraco.Ditto/Common/DittoContextAccessor.cs
+++ b/src/Our.Umbraco.Ditto/Common/DittoContextAccessor.cs
@@ -4,9 +4,9 @@ using Umbraco.Web;
 namespace Our.Umbraco.Ditto
 {
     /// <summary>
-    /// An interface allowing access to the UmbracoContext &amp; ApplicationContext without resulting to using the singletons directly.
+    /// An interface allowing access to context objects without resulting to using the singletons directly.
     /// </summary>
-    public interface IUmbracoApplicationContextAccessor
+    public interface IDittoContextAccessor
     {
         /// <summary>
         /// The UmbracoContext instance.
@@ -19,7 +19,7 @@ namespace Our.Umbraco.Ditto
         ApplicationContext ApplicationContext { get; }
     }
 
-    internal class SingletonUmbracoApplicationContextAccessor : IUmbracoApplicationContextAccessor
+    internal class DefaultDittoContextAccessor : IDittoContextAccessor
     {
         public UmbracoContext UmbracoContext
         {

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -17,9 +17,9 @@ namespace Our.Umbraco.Ditto
     public class Ditto
     {
         /// <summary>
-        /// The global umbraco application context accessor type for processors, (defaults to `SingletonUmbracoApplicationContextAccessor`).
+        /// The global context accessor type for processors.
         /// </summary>
-        private static Type umbracoApplicationContextAccessorType = typeof(SingletonUmbracoApplicationContextAccessor);
+        private static Type contextAccessorType = typeof(DefaultDittoContextAccessor);
 
         /// <summary>
         /// The Ditto processor attribute targets
@@ -142,13 +142,13 @@ namespace Our.Umbraco.Ditto
         }
 
         /// <summary>
-        /// Registers a global umbraco application context accessor.
+        /// Registers a global Ditto context accessor.
         /// </summary>
-        /// <typeparam name="TUmbracoApplicationContextAccessorType">The type of the accessor.</typeparam>
-        public static void RegisterUmbracoApplicationContextAccessor<TUmbracoApplicationContextAccessorType>()
-            where TUmbracoApplicationContextAccessorType : IUmbracoApplicationContextAccessor, new()
+        /// <typeparam name="TDittoContextAccessorType">The type of the context accessor.</typeparam>
+        public static void RegisterContextAccessor<TDittoContextAccessorType>()
+            where TDittoContextAccessorType : IDittoContextAccessor, new()
         {
-            umbracoApplicationContextAccessorType = typeof(TUmbracoApplicationContextAccessorType);
+            contextAccessorType = typeof(TDittoContextAccessorType);
         }
 
         /// <summary>
@@ -157,9 +157,9 @@ namespace Our.Umbraco.Ditto
         /// <returns>
         /// Returns the global umbraco application context accessor type.
         /// </returns>
-        public static Type GetUmbracoApplicationContextAccessorType()
+        public static Type GetContextAccessorType()
         {
-            return umbracoApplicationContextAccessorType;
+            return contextAccessorType;
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -192,7 +192,7 @@ namespace Our.Umbraco.Ditto
             }
 
             // Get the accessor for UmbracoContext & ApplicationContext
-            var umbracoApplicationContextAccessor = (IUmbracoApplicationContextAccessor)Ditto.GetUmbracoApplicationContextAccessorType().GetInstance();
+            var umbracoApplicationContextAccessor = (IDittoContextAccessor)Ditto.GetContextAccessorType().GetInstance();
 
             // Check if the culture has been set, otherwise use from Umbraco, or fallback to a default
             if (culture == null)
@@ -233,8 +233,8 @@ namespace Our.Umbraco.Ditto
         /// <param name="type">
         /// The <see cref="Type"/> of items to return.
         /// </param>
-        /// <param name="umbracoApplicationContextAccessor">
-        /// The umbraco application context accessor.
+        /// <param name="contextAccessor">
+        /// The context accessor.
         /// </param>
         /// <param name="culture">
         /// The <see cref="CultureInfo"/>
@@ -260,7 +260,7 @@ namespace Our.Umbraco.Ditto
         private static object ConvertContent(
             IPublishedContent content,
             Type type,
-            IUmbracoApplicationContextAccessor umbracoApplicationContextAccessor,
+            IDittoContextAccessor contextAccessor,
             CultureInfo culture = null,
             object instance = null,
             IEnumerable<DittoProcessorContext> processorContexts = null,
@@ -340,7 +340,7 @@ namespace Our.Umbraco.Ditto
                     var localInstance = instance;
 
                     // ReSharper disable once PossibleMultipleEnumeration
-                    lazyProperties.Add(propertyInfo.Name, new Lazy<object>(() => GetProcessedValue(content, culture, type, deferredPropertyInfo, localInstance, defaultProcessorType, umbracoApplicationContextAccessor, processorContexts)));
+                    lazyProperties.Add(propertyInfo.Name, new Lazy<object>(() => GetProcessedValue(content, culture, type, deferredPropertyInfo, localInstance, defaultProcessorType, contextAccessor, processorContexts)));
                 }
             }
 
@@ -373,7 +373,7 @@ namespace Our.Umbraco.Ditto
 
                     // Set the value normally.
                     // ReSharper disable once PossibleMultipleEnumeration
-                    var value = GetProcessedValue(content, culture, type, propertyInfo, instance, defaultProcessorType, umbracoApplicationContextAccessor, processorContexts);
+                    var value = GetProcessedValue(content, culture, type, propertyInfo, instance, defaultProcessorType, contextAccessor, processorContexts);
 
                     // This is 2x as fast as propertyInfo.SetValue(instance, value, null);
                     PropertyInfoInvocations.SetValue(propertyInfo, instance, value);
@@ -396,7 +396,7 @@ namespace Our.Umbraco.Ditto
         /// <param name="propertyInfo">The <see cref="PropertyInfo" /> property info associated with the type.</param>
         /// <param name="instance">The instance to assign the value to.</param>
         /// <param name="defaultProcessorType">The default processor type.</param>
-        /// <param name="umbracoApplicationContextAccessor">The umbraco application context accessor.</param>
+        /// <param name="contextAccessor">The context accessor.</param>
         /// <param name="processorContexts">A collection of <see cref="DittoProcessorContext" /> entities to use whilst processing values.</param>
         /// <returns>
         /// The <see cref="object" /> representing the Umbraco value.
@@ -408,7 +408,7 @@ namespace Our.Umbraco.Ditto
             PropertyInfo propertyInfo,
             object instance,
             Type defaultProcessorType,
-            IUmbracoApplicationContextAccessor umbracoApplicationContextAccessor,
+            IDittoContextAccessor contextAccessor,
             IEnumerable<DittoProcessorContext> processorContexts = null)
         {
             // Time custom value-processor.
@@ -436,11 +436,11 @@ namespace Our.Umbraco.Ditto
                     if (cacheAttr != null)
                     {
                         var ctx = new DittoCacheContext(cacheAttr, content, targetType, propertyDescriptor, culture);
-                        return cacheAttr.GetCacheItem(ctx, () => DoGetProcessedValue(content, propertyInfo, defaultProcessorType, umbracoApplicationContextAccessor, processorContexts));
+                        return cacheAttr.GetCacheItem(ctx, () => DoGetProcessedValue(content, propertyInfo, defaultProcessorType, contextAccessor, processorContexts));
                     }
                     else
                     {
-                        return DoGetProcessedValue(content, propertyInfo, defaultProcessorType, umbracoApplicationContextAccessor, processorContexts);
+                        return DoGetProcessedValue(content, propertyInfo, defaultProcessorType, contextAccessor, processorContexts);
                     }
                 }
                 finally
@@ -457,14 +457,14 @@ namespace Our.Umbraco.Ditto
         /// <param name="content">The content.</param>
         /// <param name="propertyInfo">The property information.</param>
         /// <param name="defaultProcessorType">The default processor type.</param>
-        /// <param name="umbracoApplicationContextAccessor">The umbraco application context accessor.</param>
+        /// <param name="contextAccessor">The context accessor.</param>
         /// <param name="processorContexts">The processor contexts.</param>
         /// <returns>Returns the processed value.</returns>
         private static object DoGetProcessedValue(
             IPublishedContent content,
             PropertyInfo propertyInfo,
             Type defaultProcessorType,
-            IUmbracoApplicationContextAccessor umbracoApplicationContextAccessor,
+            IDittoContextAccessor contextAccessor,
             IEnumerable<DittoProcessorContext> processorContexts = null)
         {
             // Check the property for any explicit processor attributes
@@ -520,8 +520,8 @@ namespace Our.Umbraco.Ditto
                 var ctx = DittoChainContext.Current.ProcessorContexts.GetOrCreate(processorAttr.ContextType);
 
                 // Populate UmbracoContext & ApplicationContext 
-                processorAttr.UmbracoContext = umbracoApplicationContextAccessor.UmbracoContext;
-                processorAttr.ApplicationContext = umbracoApplicationContextAccessor.ApplicationContext;
+                processorAttr.UmbracoContext = contextAccessor.UmbracoContext;
+                processorAttr.ApplicationContext = contextAccessor.ApplicationContext;
 
                 // Process value
                 currentValue = processorAttr.ProcessValue(currentValue, ctx);

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -76,7 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\CachedInvocations.cs" />
-    <Compile Include="Common\UmbracoApplicationContextAccessor.cs" />
+    <Compile Include="Common\DittoContextAccessor.cs" />
     <Compile Include="Common\PropertyInfoInvocations.cs" />
     <Compile Include="ComponentModel\Attributes\DittoDefaultProcessorAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoLazyAttribute.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/GlobalSetupFixture.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/GlobalSetupFixture.cs
@@ -9,7 +9,7 @@ namespace Our.Umbraco.Ditto.Tests
         [SetUp]
         public void Setup()
         {
-            Ditto.RegisterUmbracoApplicationContextAccessor<MockUmbracoApplicationContextAccessor>();
+            Ditto.RegisterContextAccessor<MockDittoContextAccessor>();
         }
     }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/Mocks/MockDittoContextAccessor.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/Mocks/MockDittoContextAccessor.cs
@@ -11,7 +11,7 @@ using Umbraco.Web.Security;
 
 namespace Our.Umbraco.Ditto.Tests.Mocks
 {
-    public class MockUmbracoApplicationContextAccessor : IUmbracoApplicationContextAccessor
+    public class MockDittoContextAccessor : IDittoContextAccessor
     {
         private readonly ApplicationContext _applicationContext;
         private readonly UmbracoContext _umbracoContext;
@@ -20,7 +20,7 @@ namespace Our.Umbraco.Ditto.Tests.Mocks
         /// All logic here based on https://github.com/garydevenay/Umbraco-Context-Mock/blob/f05d3da7a9442594f0735046aacaf8c7a341ff22/GDev.Umbraco.Test/ContextMocker.cs
         /// Credit goes to the original author, need to discuss whether we include this package into this test project
         /// </summary
-        public MockUmbracoApplicationContextAccessor()
+        public MockDittoContextAccessor()
         {
             ILogger loggerMock = Mock.Of<ILogger>();
             IProfiler profilerMock = Mock.Of<IProfiler>();

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -176,7 +176,7 @@
     <Compile Include="ExtremeChainedContextTests.cs" />
     <Compile Include="GlobalSetupFixture.cs" />
     <Compile Include="LazyTests.cs" />
-    <Compile Include="Mocks\MockUmbracoApplicationContextAccessor.cs" />
+    <Compile Include="Mocks\MockDittoContextAccessor.cs" />
     <Compile Include="PropertySourceMappingTests.cs" />
     <Compile Include="DittoFactoryTests.cs" />
     <Compile Include="DictionaryValueTests.cs" />


### PR DESCRIPTION
With references to PR #212, one of the queries (from PR #204) was the naming of `IUmbracoApplicationContextAccessor`.  How's about renaming it to `IDittoContextAccessor`?