### PR TITLE
XPathNavigator Processor

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoXPathAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoXPathAttribute.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Umbraco.Core;
+﻿using System.Linq;
 using Umbraco.Core.Models;
 using Umbraco.Web;
 
@@ -10,34 +7,14 @@ namespace Our.Umbraco.Ditto
     /// <summary>
     /// A processor that queries the Umbraco content cache using an XPath expression.
     /// </summary>
-    public class UmbracoXPathAttribute : DittoProcessorAttribute
+    public class UmbracoXPathAttribute : UmbracoXPathProcessorAttribute
     {
-        /// <summary>
-        /// A dictionary lookup of XPath variable names, along with corresponding functions.
-        /// </summary>
-        protected Dictionary<string, Func<IPublishedContent, string>> Lookup { get; set; }
-
-        /// <summary>
-        /// The XPath expression used to query the Umbraco content cache.
-        /// </summary>
-        public string XPath { get; set; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoXPathAttribute"/> class.
         /// </summary>
         public UmbracoXPathAttribute()
-        {
-            // This lookup attempts to simplify how Umbraco core handles the XPath syntax parsing
-            // ref: https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
-
-            Lookup = new Dictionary<string, Func<IPublishedContent, string>>()
-            {
-                { "$current", x => string.Format("id({0})", x.Id) },
-                { "$parent", x => string.Format("id({0})", x.Parent.Id) },
-                { "$site", x => string.Format("id({0})", x.Path.ToDelimitedList().ElementAtOrDefault(1) ?? "-1") },
-                { "$root", x => "/root" },
-            };
-        }
+            : base()
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UmbracoXPathAttribute"/> class.
@@ -57,40 +34,15 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public override object ProcessValue()
         {
-            if (string.IsNullOrWhiteSpace(XPath))
-                return Value;
+            var xpath = GetXPath();
 
-            var content = GetPublishedContent(Value);
-
-            if ((content == null || content.Id == 0) && UmbracoContext.Current.PageId.HasValue)
-                content = UmbracoContext.Current.ContentCache.GetById(UmbracoContext.Current.PageId.Value);
-
-            var xparam = Lookup.FirstOrDefault(x => XPath.StartsWith(x.Key));
-
-            var xpath = xparam.Key != null
-                ? XPath.Replace(xparam.Key, xparam.Value(content))
-                : XPath;
+            if (string.IsNullOrWhiteSpace(xpath))
+                return Enumerable.Empty<IPublishedContent>();
 
             return UmbracoContext
                 .Current
                 .ContentCache
                 .GetByXPath(xpath);
-        }
-
-        /// <summary>
-        /// Attempts to get the current IPublishedContent object from the value.
-        /// </summary>
-        /// <param name="value">The processor's input value.</param>
-        /// <returns>Returns an IPublishedContent object.</returns>
-        private IPublishedContent GetPublishedContent(object value)
-        {
-            if (value is IEnumerable<IPublishedContent>)
-                return ((IEnumerable<IPublishedContent>)value).FirstOrDefault();
-
-            if (value is IPublishedContent)
-                return (IPublishedContent)value;
-
-            return this.Context.Content;
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoXPathNavigatorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoXPathNavigatorAttribute.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Xml.XPath;
+using Umbraco.Web;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// A processor that queries the Umbraco content cache using the XPathNavigator.
+    /// </summary>
+    public abstract class UmbracoXPathNavigatorAttribute : UmbracoXPathProcessorAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoXPathNavigatorAttribute"/> class.
+        /// </summary>
+        public UmbracoXPathNavigatorAttribute()
+            : base()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoXPathNavigatorAttribute"/> class.
+        /// </summary>
+        /// <param name="xpath"></param>
+        public UmbracoXPathNavigatorAttribute(string xpath)
+            : this()
+        {
+            XPath = xpath;
+        }
+
+        /// <summary>
+        /// Processes the value.
+        /// </summary>
+        /// <returns>
+        /// Returns a collection of XPathNavigator objects that match the XPath expression from the Umbraco content cache.
+        /// </returns>
+        public override object ProcessValue()
+        {
+            var xpath = GetXPath();
+
+            if (string.IsNullOrWhiteSpace(xpath))
+                return Enumerable.Empty<XPathNavigator>();
+
+            return UmbracoContext
+                .Current
+                .ContentCache
+                .GetXPathNavigator()
+                .Select(xpath)
+                .Cast<XPathNavigator>();
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoXPathProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoXPathProcessorAttribute.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Web;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// An abstract processor that parses an XPath expression.
+    /// </summary>
+    public abstract class UmbracoXPathProcessorAttribute : DittoProcessorAttribute
+    {
+        /// <summary>
+        /// A dictionary lookup of XPath variable names, along with corresponding functions.
+        /// </summary>
+        protected Dictionary<string, Func<IPublishedContent, string>> Lookup { get; set; }
+
+        /// <summary>
+        /// The XPath expression used to query the Umbraco content cache.
+        /// </summary>
+        public string XPath { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoXPathProcessorAttribute"/> class.
+        /// </summary>
+        public UmbracoXPathProcessorAttribute()
+        {
+            // This lookup attempts to simplify how Umbraco core handles the XPath syntax parsing
+            // ref: https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Core/Xml/UmbracoXPathPathSyntaxParser.cs
+
+            Lookup = new Dictionary<string, Func<IPublishedContent, string>>()
+            {
+                { "$current", x => string.Format("id({0})", x.Id) },
+                { "$parent", x => string.Format("id({0})", x.Path.ToDelimitedList().Reverse().ElementAtOrDefault(1) ?? x.Parent.Id.ToString()) },
+                { "$site", x => string.Format("id({0})", x.Path.ToDelimitedList().ElementAtOrDefault(1) ?? "-1") },
+                { "$root", x => "/root" },
+            };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UmbracoXPathProcessorAttribute"/> class.
+        /// </summary>
+        /// <param name="xpath">The XPath expression used to query the Umbraco content cache.</param>
+        public UmbracoXPathProcessorAttribute(string xpath)
+            : this()
+        {
+            XPath = xpath;
+        }
+
+        /// <summary>
+        /// Attempts to get the current IPublishedContent object from the value.
+        /// </summary>
+        /// <returns>Returns an IPublishedContent object.</returns>
+        protected IPublishedContent GetPublishedContent()
+        {
+            var content = Context.Content;
+
+            if (Value is IPublishedContent)
+            {
+                content = (IPublishedContent)Value;
+            }
+            else if (Value is IEnumerable<IPublishedContent>)
+            {
+                content = ((IEnumerable<IPublishedContent>)Value).FirstOrDefault();
+            }
+
+            if ((content == null || content.Id == 0) && UmbracoContext.Current.PageId.HasValue)
+                content = UmbracoContext.Current.ContentCache.GetById(UmbracoContext.Current.PageId.Value);
+
+            return content;
+        }
+
+        /// <summary>
+        /// Gets the XPath expression, parsing the look-up placeholder tokens.
+        /// </summary>
+        /// <returns></returns>
+        protected string GetXPath()
+        {
+            if (string.IsNullOrWhiteSpace(XPath))
+                return string.Empty;
+
+            var content = GetPublishedContent();
+
+            var xparam = Lookup.FirstOrDefault(x => XPath.StartsWith(x.Key));
+
+            return xparam.Key != null
+                ? XPath.Replace(xparam.Key, xparam.Value(content))
+                : XPath;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -114,6 +114,8 @@
     <Compile Include="ComponentModel\ConversionHandlers\DittoConversionHandler.cs" />
     <Compile Include="ComponentModel\Processors\DittoProcessorRegistry.cs" />
     <Compile Include="ComponentModel\Processors\Contexts\DittoProcessorContext.cs" />
+    <Compile Include="ComponentModel\Processors\UmbracoXPathProcessorAttribute.cs" />
+    <Compile Include="ComponentModel\Processors\UmbracoXPathNavigatorAttribute.cs" />
     <Compile Include="ComponentModel\Processors\UmbracoXPathAttribute.cs" />
     <Compile Include="Ditto.cs" />
     <Compile Include="DittoChainContext.cs" />


### PR DESCRIPTION
This can be used if you need a more raw/direct query to get data from the content-cache.

Also refactored the current XPath processor, extracted out the reusable parts into an `UmbracoXPathProcessor` base class.

---

In terms of a use-case, for an events listing page, I needed a dropdown list of all the "in-use" years from the events.  I'd previously got the event listing node, looped over all the event-page child nodes, got the event date, built up a list, etc. It worked fine, but not very efficient.

Since the Umbraco content-cache can give you direct access to `GetXPathNavigator()`, we can use a direct XPath query to get the aggregated data.

Here's my usage...

```csharp
[InUseYears("$current/ancestor-or-self::homepage/eventListing[1]/eventPage/eventDate[normalize-space(.)]")]
public IEnumerable<int> Years { get; set; }
```

```csharp
public class InUseYearsAttribute : XPathNavigatorAttribute
{
	public InUseYearsAttribute(string xpath)
	{
		XPath = xpath;
	}

	public override object ProcessValue()
	{
		var items = base.ProcessValue() as IEnumerable<XPathNavigator>;

		return items
			.Select(x => x.ValueAsDateTime.Year)
			.Distinct()
			.OrderByDescending(x => x);
	}
}
```

With limit miniprofiler benchmarks, my original processor ran at around 100ms, then using XPathNavigator came down to 0.5ms.