### PR TITLE
With OnConverting, should the Content object be mutable?

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandler.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandler.cs
@@ -121,6 +121,9 @@ namespace Our.Umbraco.Ditto
             this.Model = ctx.Model as TConvertedType;
 
             this.Run(type);
+
+            if (type == DittoConversionHandlerType.OnConverting && this.Content != ctx.Content)
+                ctx.Content = this.Content;
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -343,7 +343,7 @@ namespace Our.Umbraco.Ditto
 
             // We have the instance object but haven't yet populated properties
             // so fire the on converting event handlers
-            OnConverting(content, type, instance, onConverting);
+            OnConverting(ref content, type, instance, onConverting);
 
             // Process any non lazy properties next
             foreach (var propertyInfo in properties.Where(x => !x.ShouldAttemptLazyLoad()))
@@ -368,7 +368,7 @@ namespace Our.Umbraco.Ditto
 
             // We have now finished populating the instance object so go ahead
             // and fire the on converted event handlers
-            OnConverted(content, type, instance, onConverted);
+            OnConverted(ref content, type, instance, onConverted);
 
             return instance;
         }
@@ -536,14 +536,14 @@ namespace Our.Umbraco.Ditto
         /// The <see cref="Action{ConversionHandlerContext}"/> to fire when converting.
         /// </param>
         private static void OnConverting(
-            IPublishedContent content,
+            ref IPublishedContent content,
             Type type,
             object instance,
             Action<DittoConversionHandlerContext> callback = null)
         {
             OnConvert<DittoOnConvertingAttribute>(
                 DittoConversionHandlerType.OnConverting,
-                content,
+                ref content,
                 type,
                 instance,
                 callback);
@@ -559,14 +559,14 @@ namespace Our.Umbraco.Ditto
         /// The <see cref="Action{ConversionHandlerContext}"/> to fire when converted.
         /// </param>
         private static void OnConverted(
-            IPublishedContent content,
+            ref IPublishedContent content,
             Type type,
             object instance,
             Action<DittoConversionHandlerContext> callback = null)
         {
             OnConvert<DittoOnConvertedAttribute>(
                 DittoConversionHandlerType.OnConverted,
-                content,
+                ref content,
                 type,
                 instance,
                 callback);
@@ -583,7 +583,7 @@ namespace Our.Umbraco.Ditto
         /// <param name="callback">The callback.</param>
         private static void OnConvert<TAttributeType>(
             DittoConversionHandlerType conversionType,
-            IPublishedContent content,
+            ref IPublishedContent content,
             Type type,
             object instance,
             Action<DittoConversionHandlerContext> callback = null)
@@ -627,6 +627,10 @@ namespace Our.Umbraco.Ditto
             {
                 callback(conversionCtx);
             }
+
+            // When converting, if the IPublishedContent has changed, pass back the reference
+            if (conversionType == DittoConversionHandlerType.OnConverting && conversionCtx.Content != content)
+                content = conversionCtx.Content;
         }
     }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/ChangePublishedContentOnConvertingTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ChangePublishedContentOnConvertingTests.cs
@@ -1,0 +1,34 @@
+﻿using NUnit.Framework;
+using Our.Umbraco.Ditto.Tests.Mocks;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    [Category("Mapping"), Category("ConversionHandlers")]
+    public class ChangePublishedContentOnConvertingTests
+    {
+        [DittoConversionHandler(typeof(MyModelConversionHandler))]
+        public class MyModel
+        {
+            public string Name { get; set; }
+        }
+
+        public class MyModelConversionHandler : DittoConversionHandler<MyModel>
+        {
+            public override void OnConverting()
+            {
+                Content = new MockPublishedContent { Name = "Different" };
+            }
+        }
+
+        [Test]
+        public void ChangePublishedContent_OnConverting_IsMapped()
+        {
+            var content = new MockPublishedContent { Name = "Original" };
+
+            var model = content.As<MyModel>();
+
+            Assert.That(model.Name, Is.EqualTo("Different"));
+        }
+    }
+}

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -172,6 +172,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="ChangePublishedContentOnConvertingTests.cs" />
     <Compile Include="EnumerableConverterTests.cs" />
     <Compile Include="ExtremeChainedContextTests.cs" />
     <Compile Include="LazyTests.cs" />


### PR DESCRIPTION
Currently with the `OnConverting` event, if you try to set the `Content` property of the `DittoConversionHandlerContext` container object, it doesn't update the original reference of the `IPublishedContent` object.

**My question is, conceptually, should we be able to replace/amend the `IPublishedContent` within an `OnConverting` event?**

---

_I do have an edge-case requirement for this. I'm happy to explain if needed, but wanted to keep the initial question simple._