### PR TITLE
Makes the DittoConversionHandlerContext property setters internal

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerContext.cs
@@ -12,21 +12,21 @@ namespace Our.Umbraco.Ditto
         /// <summary>
         /// Gets or sets the content.
         /// </summary>
-        public IPublishedContent Content { get; set; }
+        public IPublishedContent Content { get; protected internal set; }
 
         /// <summary>
         /// Gets or sets the culture.
         /// </summary>
-        public CultureInfo Culture { get; set; }
+        public CultureInfo Culture { get; protected internal set; }
 
         /// <summary>
         /// Gets or sets the model object.
         /// </summary>
-        public object Model { get; set; }
+        public object Model { get; protected internal set; }
 
         /// <summary>
         /// Gets or sets the model type.
         /// </summary>
-        public Type ModelType { get; set; }
+        public Type ModelType { get; protected internal set; }
     }
 }


### PR DESCRIPTION
Following on from #215, this PR makes the `DittoConversionHandlerContext` mark the properties setters as `protected internal`

Hopefully, this will help clear any confusion about the context properties (e.g. the IPublishedContent) being assignable.