### PR TITLE
DittoConversionHandler - replace Content/Model properties with a Context property

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandler.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Umbraco.Core.Models;
-
-namespace Our.Umbraco.Ditto
+﻿namespace Our.Umbraco.Ditto
 {
     /// <summary>
     /// The types of conversion handler.
@@ -26,28 +23,12 @@ namespace Our.Umbraco.Ditto
     public abstract class DittoConversionHandler
     {
         /// <summary>
-        /// Gets or sets the current IPublishedContent.
+        /// Gets or sets the current DittoConversionHandlerContext.
         /// </summary>
         /// <value>
-        /// The content.
+        /// The context.
         /// </value>
-        public IPublishedContent Content { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the type of the model.
-        /// </summary>
-        /// <value>
-        /// The type of the model.
-        /// </value>
-        public Type ModelType { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the model.
-        /// </summary>
-        /// <value>
-        /// The model.
-        /// </value>
-        public object Model { get; protected set; }
+        public DittoConversionHandlerContext Context { get; protected set; }
 
         /// <summary>
         /// Called just before conversion of the model occurs.
@@ -68,9 +49,7 @@ namespace Our.Umbraco.Ditto
         /// <param name="type">The handler type to run.</param>
         internal virtual void Run(DittoConversionHandlerContext ctx, DittoConversionHandlerType type)
         {
-            this.Content = ctx.Content;
-            this.ModelType = ctx.ModelType;
-            this.Model = ctx.Model;
+            this.Context = ctx;
 
             this.Run(type);
         }
@@ -102,12 +81,12 @@ namespace Our.Umbraco.Ditto
         where TConvertedType : class
     {
         /// <summary>
-        /// Gets or sets the model.
+        /// Gets or sets the current DittoConversionHandlerContext.
         /// </summary>
         /// <value>
-        /// The model.
+        /// The context.
         /// </value>
-        public new TConvertedType Model { get; protected set; }
+        public new DittoConversionHandlerContext<TConvertedType> Context { get; protected set; }
 
         /// <summary>
         /// Runs the conversion handler.
@@ -116,9 +95,7 @@ namespace Our.Umbraco.Ditto
         /// <param name="type">The handler type to run.</param>
         internal override void Run(DittoConversionHandlerContext ctx, DittoConversionHandlerType type)
         {
-            this.Content = ctx.Content;
-            this.ModelType = ctx.ModelType;
-            this.Model = ctx.Model as TConvertedType;
+            this.Context = new DittoConversionHandlerContext<TConvertedType>(ctx);
 
             this.Run(type);
         }

--- a/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ConversionHandlers/DittoConversionHandlerContext.cs
@@ -29,4 +29,34 @@ namespace Our.Umbraco.Ditto
         /// </summary>
         public Type ModelType { get; set; }
     }
+
+    /// <summary>
+    /// Provides context for conversion events, with a generic model object type.
+    /// </summary>
+    public class DittoConversionHandlerContext<TConvertedType> : DittoConversionHandlerContext
+        where TConvertedType : class
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoConversionHandlerContext"/> class.
+        /// </summary>
+        public DittoConversionHandlerContext()
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DittoConversionHandlerContext"/> class.
+        /// </summary>
+        /// <param name="ctx">The context.</param>
+        internal DittoConversionHandlerContext(DittoConversionHandlerContext ctx)
+        {
+            this.Content = ctx.Content;
+            this.Culture = ctx.Culture;
+            this.ModelType = ctx.ModelType;
+            this.Model = ctx.Model as TConvertedType;
+        }
+
+        /// <summary>
+        /// Gets or sets the model object.
+        /// </summary>
+        public new TConvertedType Model { get; protected internal set; }
+    }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -1,18 +1,17 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Web;
 
 namespace Our.Umbraco.Ditto
 {
-    using global::Umbraco.Core;
-    using System.Collections;
-
     /// <summary>
     /// Encapsulates extension methods for <see cref="IPublishedContent"/>.
     /// </summary>
@@ -633,7 +632,7 @@ namespace Our.Umbraco.Ditto
                 Model = instance
             };
 
-            // Check for class level DittoOnConvertedAttribute
+            // Check for class level DittoConversionHandlerAttribute
             foreach (var attr in type.GetCustomAttributes<DittoConversionHandlerAttribute>())
             {
                 ((DittoConversionHandler)attr.HandlerType.GetInstance())
@@ -647,7 +646,7 @@ namespace Our.Umbraco.Ditto
                     .Run(conversionCtx, conversionType);
             }
 
-            // Check for method level DittoOnConvertedAttribute
+            // Check for method level DittoOnConvert[ing|ed]Attribute
             foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(x => x.GetCustomAttribute<TAttributeType>() != null))
             {

--- a/tests/Our.Umbraco.Ditto.Tests/ConversionHandlerTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ConversionHandlerTests.cs
@@ -51,7 +51,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override void OnConverted()
             {
-                Model.AltText2 = Content.GetPropertyValue("prop1") + " " + Content.GetPropertyValue("prop2");
+                Context.Model.AltText2 = Context.Content.GetPropertyValue("prop1") + " " + Context.Content.GetPropertyValue("prop2");
             }
         }
 
@@ -59,7 +59,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override void OnConverted()
             {
-                Model.AltText2 = Content.GetPropertyValue("prop1") + " " + Content.GetPropertyValue("prop2");
+                Context.Model.AltText2 = Context.Content.GetPropertyValue("prop1") + " " + Context.Content.GetPropertyValue("prop2");
             }
         }
 

--- a/tests/Our.Umbraco.Ditto.Tests/MultipleConversionHandlerTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/MultipleConversionHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override void OnConverted()
             {
-                Model.Name = "foo";
+                Context.Model.Name = "foo";
             }
         }
 
@@ -24,7 +24,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override void OnConverted()
             {
-                Model.Name += " bar";
+                Context.Model.Name += " bar";
             }
         }
 


### PR DESCRIPTION
**Forewarning: Breaking Change**

@mattbrailsford You're gonna hate on me for this! :laughing:

After adding the `Culture` property to `DittoConversionHandlerContext ` (in PR #216). I'd later noticed that I'd missed adding it on `DittoConversionHandler`.

Which got me thinking, why are we duplicating properties here? Wouldn't it be better to access the Content, Model, ModelType (and now Culture) via a Context property?

> Which is conceptually the same as we do in Processors - and the method-level `DittoOnConvertedAttribute` - those properties hang off a context object.

Of course, this being a breaking change, I don't take it lightly, hence seeking peer approval. ❤️ 