### PR TITLE
DittoView: Enhancement to support unwrapping & downcasting view-models

### DIFF
--- a/src/Our.Umbraco.Ditto/Web/Mvc/DittoView.cs
+++ b/src/Our.Umbraco.Ditto/Web/Mvc/DittoView.cs
@@ -63,8 +63,6 @@ namespace Our.Umbraco.Ditto
             var baseDittoViewModel = model as BaseDittoViewModel;
             if (baseDittoViewModel != null)
             {
-                content = baseDittoViewModel.Content ?? content;
-                culture = baseDittoViewModel.CurrentCulture ?? culture;
                 processorContexts.AddRange(baseDittoViewModel.ProcessorContexts);
 
                 // Furthermore, check if the model is generic/wrapped; Unwrap the inner view-model

--- a/src/Our.Umbraco.Ditto/Web/Mvc/DittoView.cs
+++ b/src/Our.Umbraco.Ditto/Web/Mvc/DittoView.cs
@@ -49,16 +49,6 @@ namespace Our.Umbraco.Ditto
                 processorContexts = transferModel.ProcessorContexts;
             }
 
-            // Get current content
-            var content = this.UmbracoContext.PublishedContentRequest != null
-                ? this.UmbracoContext.PublishedContentRequest.PublishedContent
-                : default(IPublishedContent);
-
-            // Get current culture
-            var culture = this.UmbracoContext.PublishedContentRequest != null
-                ? this.UmbracoContext.PublishedContentRequest.Culture
-                : CultureInfo.CurrentCulture;
-
             // Check if the model is a Ditto base view-model; Use the assigned properties
             var baseDittoViewModel = model as BaseDittoViewModel;
             if (baseDittoViewModel != null)
@@ -72,6 +62,16 @@ namespace Our.Umbraco.Ditto
                     var viewProperty = modelType.GetProperty("View", Ditto.MappablePropertiesBindingFlags);
                     model = FastPropertyAccessor.GetValue(viewProperty, model);
                 }
+            }
+
+            var content = default(IPublishedContent);
+            var culture = CultureInfo.CurrentCulture;
+
+            // Get current content / culture
+            if (this.UmbracoContext.PublishedContentRequest != null)
+            {
+                content = this.UmbracoContext.PublishedContentRequest.PublishedContent;
+                culture = this.UmbracoContext.PublishedContentRequest.Culture;
             }
 
             // Process model


### PR DESCRIPTION
@mattbrailsford - I'd found an scenario a while back where if a `DittoView<T>` page referenced another `DittoView<T>` page, but the view-model was castable, the code wouldn't cast it and Ditto would recreate the object.

That might sound like a mouthful, but I'll try to explain...

Say you've got these POCOs...

```csharp
public class MasterModel
{
  public string Something { get; set; }
}

public class OtherModel : MasterModel
{
  public string Whatever { get; set; }
}
```

If you had `DittoView<OtherModel>` on a page template, and `DittoView<MasterModel>` on the layout template, the DittoView code would be creating the object twice, rather than downcasting it to the inherited type.

This PR adds in a check to see if the model object is a `DittoViewModel<>` and to unwrap the inner view-model, so it can be reused.

Hopefully this makes sense?  (and is backwards compatible / a non-breaking change)