### PR TITLE
Post processors - Adds methods to register/deregister

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
@@ -11,9 +11,9 @@ namespace Our.Umbraco.Ditto
     internal class DittoProcessorRegistry
     {
         /// <summary>
-        /// The cache for storing handler information.
+        /// The cache for storing processors associated by type.
         /// </summary>
-        private static readonly Dictionary<Type, List<DittoProcessorAttribute>> Cache = new Dictionary<Type, List<DittoProcessorAttribute>>();
+        private static readonly Dictionary<Type, List<DittoProcessorAttribute>> ProcessorCache = new Dictionary<Type, List<DittoProcessorAttribute>>();
 
         /// <summary>
         /// Static holder for singleton instance.
@@ -21,9 +21,9 @@ namespace Our.Umbraco.Ditto
         private static readonly Lazy<DittoProcessorRegistry> InternalInstance = new Lazy<DittoProcessorRegistry>(() => new DittoProcessorRegistry());
 
         /// <summary>
-        /// The lock object to make Cache access thread safe
+        /// The lock object to make ProcessorCache access thread safe.
         /// </summary>
-        private static readonly object CacheLock = new object();
+        private static readonly object ProcessorCacheLock = new object();
 
         /// <summary>
         /// The default processor type, (defaults to `UmbracoProperty`).
@@ -93,14 +93,14 @@ namespace Our.Umbraco.Ditto
         {
             var objType = typeof(TObjectType);
 
-            lock (CacheLock)
+            lock (ProcessorCacheLock)
             {
-                if (!Cache.ContainsKey(objType))
+                if (!ProcessorCache.ContainsKey(objType))
                 {
-                    Cache.Add(objType, new List<DittoProcessorAttribute>());
+                    ProcessorCache.Add(objType, new List<DittoProcessorAttribute>());
                 }
 
-                Cache[objType].Add(instance);
+                ProcessorCache[objType].Add(instance);
             }
         }
 
@@ -142,10 +142,10 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public IEnumerable<DittoProcessorAttribute> GetRegisteredProcessorAttributesFor(Type objectType)
         {
-            lock (CacheLock)
+            lock (ProcessorCacheLock)
             {
-                return Cache.ContainsKey(objectType)
-                    ? Cache[objectType]
+                return ProcessorCache.ContainsKey(objectType)
+                    ? ProcessorCache[objectType]
                     : Enumerable.Empty<DittoProcessorAttribute>();
             }
         }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
@@ -31,6 +31,17 @@ namespace Our.Umbraco.Ditto
         private Type DefaultProcessorType = typeof(UmbracoPropertyAttribute);
 
         /// <summary>
+        /// The default post-processors.
+        /// </summary>
+        private List<DittoProcessorAttribute> DefaultPostProcessorAttributes = new List<DittoProcessorAttribute>()
+        {
+            new HtmlStringAttribute(),
+            new EnumerableConverterAttribute(),
+            new RecursiveDittoAttribute(),
+            new TryConvertToAttribute()
+        };
+
+        /// <summary>
         /// Prevents a default instance of the <see cref="DittoProcessorRegistry"/> class from being created.
         /// </summary>
         private DittoProcessorRegistry()
@@ -119,11 +130,7 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public IEnumerable<DittoProcessorAttribute> GetPostProcessorAttributes()
         {
-            // TODO: [LK] Enable the post-processor attributes to be configurable
-            yield return new HtmlStringAttribute();
-            yield return new EnumerableConverterAttribute();
-            yield return new RecursiveDittoAttribute();
-            yield return new TryConvertToAttribute();
+            return this.DefaultPostProcessorAttributes;
         }
 
         /// <summary>
@@ -141,6 +148,36 @@ namespace Our.Umbraco.Ditto
                     ? Cache[objectType]
                     : Enumerable.Empty<DittoProcessorAttribute>();
             }
-        }        
+        }
+
+        /// <summary>
+        /// Registers a processor attribute to the end of the default set of post-processor attributes.
+        /// </summary>
+        /// <typeparam name="TProcessorAttributeType"></typeparam>
+        /// <param name="position"></param>
+        public void RegisterPostProcessorAttribute<TProcessorAttributeType>(int position = -1)
+            where TProcessorAttributeType : DittoProcessorAttribute, new()
+        {
+            var processor = (DittoProcessorAttribute)typeof(TProcessorAttributeType).GetInstance();
+
+            if (position < 0)
+            {
+                this.DefaultPostProcessorAttributes.Add(processor);
+            }
+            else
+            {
+                this.DefaultPostProcessorAttributes.Insert(position, processor);
+            }
+        }
+
+        /// <summary>
+        /// Unregisters a processor attribute from the default set of post-processor attributes.
+        /// </summary>
+        /// <typeparam name="TProcessorAttributeType"></typeparam>
+        public void UnregisterPostProcessorAttribute<TProcessorAttributeType>()
+             where TProcessorAttributeType : DittoProcessorAttribute, new()
+        {
+            this.DefaultPostProcessorAttributes.RemoveAll(x => x is TProcessorAttributeType);
+        }
     }
 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
@@ -171,10 +171,10 @@ namespace Our.Umbraco.Ditto
         }
 
         /// <summary>
-        /// Unregisters a processor attribute from the default set of post-processor attributes.
+        /// Deregisters a processor attribute from the default set of post-processor attributes.
         /// </summary>
         /// <typeparam name="TProcessorAttributeType"></typeparam>
-        public void UnregisterPostProcessorAttribute<TProcessorAttributeType>()
+        public void DeregisterPostProcessorAttribute<TProcessorAttributeType>()
              where TProcessorAttributeType : DittoProcessorAttribute, new()
         {
             this.DefaultPostProcessorAttributes.RemoveAll(x => x is TProcessorAttributeType);

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -174,13 +174,13 @@ namespace Our.Umbraco.Ditto
         }
 
         /// <summary>
-        /// Unregisters a processor attribute from the default set of post-processor attributes.
+        /// Deregisters a processor attribute from the default set of post-processor attributes.
         /// </summary>
         /// <typeparam name="TProcessorAttributeType"></typeparam>
-        public static void UnregisterPostProcessorAttribute<TProcessorAttributeType>()
+        public static void DeregisterPostProcessorAttribute<TProcessorAttributeType>()
             where TProcessorAttributeType : DittoProcessorAttribute, new()
         {
-            DittoProcessorRegistry.Instance.UnregisterPostProcessorAttribute<TProcessorAttributeType>();
+            DittoProcessorRegistry.Instance.DeregisterPostProcessorAttribute<TProcessorAttributeType>();
         }
     }
 }

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -161,5 +161,26 @@ namespace Our.Umbraco.Ditto
         {
             return contextAccessorType;
         }
+
+        /// <summary>
+        /// Registers a processor attribute to the end of the default set of post-processor attributes.
+        /// </summary>
+        /// <typeparam name="TProcessorAttributeType"></typeparam>
+        /// <param name="position"></param>
+        public static void RegisterPostProcessorAttribute<TProcessorAttributeType>(int position = -1)
+            where TProcessorAttributeType : DittoProcessorAttribute, new()
+        {
+            DittoProcessorRegistry.Instance.RegisterPostProcessorAttribute<TProcessorAttributeType>(position);
+        }
+
+        /// <summary>
+        /// Unregisters a processor attribute from the default set of post-processor attributes.
+        /// </summary>
+        /// <typeparam name="TProcessorAttributeType"></typeparam>
+        public static void UnregisterPostProcessorAttribute<TProcessorAttributeType>()
+            where TProcessorAttributeType : DittoProcessorAttribute, new()
+        {
+            DittoProcessorRegistry.Instance.UnregisterPostProcessorAttribute<TProcessorAttributeType>();
+        }
     }
 }


### PR DESCRIPTION
@mattbrailsford What are you're thoughts on the implementation?
A basic list with the register/unregister methods, wrapping the list's add/insert/remove methods.

I'd looked at making the entire post-processors list replaceable, but `RecursiveDittoAttribute` and `TryConvertToAttribute` are marked as internal, so that wasn't ideal, (and I don't want to change those to public).

For the unregister one, it gives me the option to exclude the `HtmlString` processor when I don't need it.