### PR TITLE
Fix proxy generation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
-image: Visual Studio 2017
-
+os: Visual Studio 2015
 
 # version format
 version: 0.11.1.{build}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-os: Visual Studio 2015
+image: Visual Studio 2017
+
 
 # version format
 version: 0.11.1.{build}

--- a/src/Our.Umbraco.Ditto/Extensions/Internal/PropertyInfoExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/Internal/PropertyInfoExtensions.cs
@@ -66,8 +66,13 @@ namespace Our.Umbraco.Ditto
         /// <returns>True if a lazy load attempt should be make</returns>
         public static bool ShouldAttemptLazyLoad(this PropertyInfo source)
         {
-            return source.HasCustomAttribute<DittoLazyAttribute>() || 
-                ((source.DeclaringType.HasCustomAttribute<DittoLazyAttribute>() || Ditto.LazyLoadStrategy == LazyLoad.AllVirtuals) 
+            if (source.HasCustomAttribute<DittoIgnoreAttribute>())
+            {
+                return false;
+            }
+
+            return source.HasCustomAttribute<DittoLazyAttribute>() ||
+                ((source.DeclaringType.HasCustomAttribute<DittoLazyAttribute>() || Ditto.LazyLoadStrategy == LazyLoad.AllVirtuals)
                     && source.IsVirtualAndOverridable());
         }
     }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -279,7 +279,8 @@ namespace Our.Umbraco.Ditto
             DittoChainContext chainContext)
         {
             // Collect all the properties of the given type and loop through writable ones.
-            PropertyCache.TryGetValue(type, out var properties);
+            PropertyInfo[] properties;
+            PropertyCache.TryGetValue(type, out properties);
 
             if (properties == null)
             {

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using Umbraco.Core;
 using Umbraco.Core.Models;
-using Umbraco.Web;
 
 namespace Our.Umbraco.Ditto
 {
@@ -197,7 +196,7 @@ namespace Our.Umbraco.Ditto
             // Ensure instance is of target type
             if (instance != null && !type.IsInstanceOfType(instance))
             {
-                throw new ArgumentException($"The instance parameter does not implement Type '{type.Name}'", "instance");
+                throw new ArgumentException($"The instance parameter does not implement Type '{type.Name}'", nameof(instance));
             }
 
             // Get the context accessor (for access to ApplicationContext, UmbracoContext, et al)
@@ -206,15 +205,9 @@ namespace Our.Umbraco.Ditto
             // Check if the culture has been set, otherwise use from Umbraco, or fallback to a default
             if (culture == null)
             {
-                if (contextAccessor.UmbracoContext != null && contextAccessor.UmbracoContext.PublishedContentRequest != null)
-                {
-                    culture = contextAccessor.UmbracoContext.PublishedContentRequest.Culture;
-                }
-                else
-                {
-                    // Fallback
-                    culture = CultureInfo.CurrentCulture;
-                }
+                culture = contextAccessor.UmbracoContext?.PublishedContentRequest != null
+                    ? contextAccessor.UmbracoContext.PublishedContentRequest.Culture
+                    : CultureInfo.CurrentCulture;
             }
 
             // Ensure a chain context
@@ -285,41 +278,8 @@ namespace Our.Umbraco.Ditto
             Action<DittoConversionHandlerContext> onConverted,
             DittoChainContext chainContext)
         {
-            // Get the default constructor, parameters and create an instance of the type.
-            ParameterInfo[] constructorParams = type.GetConstructorParameters();
-            bool hasParameter = false;
-
-            // If not already an instance, create an instance of the object
-            if (instance == null)
-            {
-                if (constructorParams != null && constructorParams.Length == 0)
-                {
-                    // Internally this uses Activator.CreateInstance which is heavily optimized.
-                    instance = type.GetInstance();
-                }
-                else if (constructorParams != null && constructorParams.Length == 1 && constructorParams[0].ParameterType == typeof(IPublishedContent))
-                {
-                    // This extension method is about 7x faster than the native implementation.
-                    instance = type.GetInstance(content);
-                    hasParameter = true;
-                }
-                else
-                {
-                    // No valid constructor, but see if the value can be cast to the type
-                    if (type.IsInstanceOfType(content))
-                    {
-                        instance = content;
-                    }
-                    else
-                    {
-                        throw new InvalidOperationException($"Can't convert IPublishedContent to {type} as it has no valid constructor. A valid constructor is either an empty one, or one accepting a single IPublishedContent parameter.");
-                    }
-                }
-            }
-
             // Collect all the properties of the given type and loop through writable ones.
-            PropertyInfo[] properties;
-            PropertyCache.TryGetValue(type, out properties);
+            PropertyCache.TryGetValue(type, out var properties);
 
             if (properties == null)
             {
@@ -329,55 +289,102 @@ namespace Our.Umbraco.Ditto
                 PropertyCache.TryAdd(type, properties);
             }
 
-            // Gets the default processor for this conversion.
-            var defaultProcessorType = DittoProcessorRegistry.Instance.GetDefaultProcessorType(type);
+            // Check the validity of the mpped type constructor as early as possible.
+            ParameterInfo[] constructorParams = type.GetConstructorParameters();
+            bool validConstructor = false;
+            bool hasParameter = false;
+            bool isType = false;
+            bool hasLazy = false;
 
-            // A dictionary to store lazily invoked values.
-            var lazyProperties = new Dictionary<string, Lazy<object>>();
-
-            // process lazy load properties first
-            foreach (var propertyInfo in properties.Where(x => x.ShouldAttemptLazyLoad()))
+            if (constructorParams != null)
             {
-                // Configure lazy properties
-                using (DittoDisposableTimer.DebugDuration<Ditto>($"Lazy Property ({content.Id} {propertyInfo.Name})"))
+                // Is it PublishedContentmModel or similar?
+                if (constructorParams.Length == 1 && constructorParams[0].ParameterType == typeof(IPublishedContent))
                 {
-                    // Ensure it's a virtual property (Only relevant to property level lazy loads)
-                    if (!propertyInfo.IsVirtualAndOverridable())
-                    {
-                        throw new InvalidOperationException($"Lazy property '{propertyInfo.Name}' of type '{type.AssemblyQualifiedName}' must be declared virtual in order to be lazy loadable.");
-                    }
+                    hasParameter = true;
+                }
 
-                    // Check for the ignore attribute (Only relevant to class level lazy loads).
-                    if (propertyInfo.HasCustomAttribute<DittoIgnoreAttribute>())
-                    {
-                        continue;
-                    }
-
-                    // Create a Lazy<object> to deferr returning our value.
-                    var deferredPropertyInfo = propertyInfo;
-                    var localInstance = instance;
-
-                    // ReSharper disable once PossibleMultipleEnumeration
-                    lazyProperties.Add(propertyInfo.Name, new Lazy<object>(() => GetProcessedValue(content, culture, type, deferredPropertyInfo, localInstance, defaultProcessorType, contextAccessor, chainContext)));
+                if (constructorParams.Length == 0 || hasParameter)
+                {
+                    validConstructor = true;
                 }
             }
 
-            if (lazyProperties.Any())
+            // No valid constructor, but see if the value can be cast to the type
+            if (type.IsInstanceOfType(content))
             {
-                // Create a proxy instance to replace our object.
-                var interceptor = new LazyInterceptor(instance, lazyProperties);
-                var factory = new ProxyFactory();
+                isType = true;
+                validConstructor = true;
+            }
 
-                instance = hasParameter
-                    ? factory.CreateProxy(type, interceptor, content)
-                    : factory.CreateProxy(type, interceptor);
+            if (!validConstructor)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot convert IPublishedContent to {type} as it has no valid constructor. " +
+                    "A valid constructor is either an empty one, or one accepting a single IPublishedContent parameter.");
+            }
+
+            // Gets the default processor for this conversion.
+            var defaultProcessorType = DittoProcessorRegistry.Instance.GetDefaultProcessorType(type);
+            PropertyInfo[] lazyProperties = null;
+
+            // If not already an instance, create an instance of the object
+            if (instance == null)
+            {
+                // We can only proxy new instances.
+                lazyProperties = properties.Where(x => x.ShouldAttemptLazyLoad()).ToArray();
+
+                if (lazyProperties.Any())
+                {
+                    hasLazy = true;
+
+                    var factory = new ProxyFactory();
+                    instance = hasParameter
+                        ? factory.CreateProxy(type, lazyProperties.Select(x => x.Name), content)
+                        : factory.CreateProxy(type, lazyProperties.Select(x => x.Name));
+
+                }
+                else if (isType)
+                {
+                    instance = content;
+                }
+                else
+                {
+                    // 1: This extension method is about 7x faster than the native implementation.
+                    // 2: Internally this uses Activator.CreateInstance which is heavily optimized.
+                    instance = hasParameter
+                        ? type.GetInstance(content) // 1
+                        : type.GetInstance(); // 2
+                }
             }
 
             // We have the instance object but haven't yet populated properties
             // so fire the on converting event handlers
             OnConverting(content, type, culture, instance, onConverting);
 
-            // Process any non lazy properties next
+            if (hasLazy)
+            {
+                // A dictionary to store lazily invoked values.
+                var lazyMappings = new Dictionary<string, Lazy<object>>();
+                foreach (var propertyInfo in lazyProperties)
+                {
+                    // Configure lazy properties
+                    using (DittoDisposableTimer.DebugDuration<Ditto>($"Lazy Property ({content.Id} {propertyInfo.Name})"))
+                    {
+                        // Ensure it's a virtual property (Only relevant to property level lazy loads)
+                        if (!propertyInfo.IsVirtualAndOverridable())
+                        {
+                            throw new InvalidOperationException($"Lazy property '{propertyInfo.Name}' of type '{type.AssemblyQualifiedName}' must be declared virtual in order to be lazy loadable.");
+                        }
+
+                        lazyMappings.Add(propertyInfo.Name, new Lazy<object>(() => GetProcessedValue(content, culture, type, propertyInfo, instance, defaultProcessorType, contextAccessor, chainContext)));
+                    }
+                }
+
+                ((IProxy)instance).Interceptor = new LazyInterceptor(lazyMappings);
+            }
+
+            // Process any non lazy properties
             foreach (var propertyInfo in properties.Where(x => !x.ShouldAttemptLazyLoad()))
             {
                 // Check for the ignore attribute.
@@ -387,7 +394,6 @@ namespace Our.Umbraco.Ditto
                 }
 
                 // Set the value normally.
-                // ReSharper disable once PossibleMultipleEnumeration
                 var value = GetProcessedValue(content, culture, type, propertyInfo, instance, defaultProcessorType, contextAccessor, chainContext);
 
                 // This over 4x faster as propertyInfo.SetValue(instance, value, null);

--- a/src/Our.Umbraco.Ditto/Proxy/LazyInterceptor.cs
+++ b/src/Our.Umbraco.Ditto/Proxy/LazyInterceptor.cs
@@ -9,75 +9,57 @@ namespace Our.Umbraco.Ditto
     /// </summary>
     internal class LazyInterceptor : IInterceptor
     {
-        /// <summary>
-        /// The lazy dictionary.
-        /// </summary>
         private readonly Dictionary<string, Lazy<object>> lazyDictionary = new Dictionary<string, Lazy<object>>();
-
-        /// <summary>
-        /// The base target instance from which the proxy type is derived.
-        /// </summary>
-        private readonly object target;
+        private readonly Dictionary<string, object> nonLazyDictionary = new Dictionary<string, object>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LazyInterceptor"/> class.
         /// </summary>
-        /// <param name="target">
-        /// The base target instance from which the proxy type is derived.
-        /// </param>
         /// <param name="values">
         /// The dictionary of values containing the property name to replace and the value to replace it with.
         /// </param>
-        public LazyInterceptor(object target, Dictionary<string, Lazy<object>> values)
+        public LazyInterceptor(Dictionary<string, Lazy<object>> values)
         {
-            this.target = target;
-
             foreach (KeyValuePair<string, Lazy<object>> pair in values)
             {
                 this.lazyDictionary.Add(pair.Key, pair.Value);
             }
         }
 
-        /// <summary>
-        /// Intercepts the <see cref="MethodBase"/> in the proxy to return a replaced value.
-        /// </summary>
-        /// <param name="methodBase">
-        /// The <see cref="MethodBase"/> containing information about the current
-        /// invoked property.
-        /// </param>
-        /// <param name="value">
-        /// The object to set the <see cref="MethodBase"/> to if it is a setter.
-        /// </param>
-        /// <returns>
-        /// The <see cref="object"/> replacing the original implementation value.
-        /// </returns>
+        /// <inheritdoc />
         public object Intercept(MethodBase methodBase, object value)
         {
-            const string Getter = "get_";
-            const string Setter = "set_";
-            var name = methodBase.Name;
-            var key = name.Substring(4);
-            var parameters = value == null ? new object[] { } : new[] { value };
+            const string getter = "get_";
+            const string setter = "set_";
+            string name = methodBase.Name;
+            string key = name.Substring(4);
 
             // Attempt to get the value from the lazy members.
-            if (name.StartsWith(Getter))
+            if (name.StartsWith(getter))
             {
                 if (this.lazyDictionary.ContainsKey(key))
                 {
                     return this.lazyDictionary[key].Value;
                 }
+
+                if (this.nonLazyDictionary.ContainsKey(key))
+                {
+                    return this.nonLazyDictionary[key];
+                }
             }
 
             // Set the value, remove the old lazy value.
-            if (name.StartsWith(Setter))
+            if (name.StartsWith(setter))
             {
                 if (this.lazyDictionary.ContainsKey(key))
                 {
                     this.lazyDictionary.Remove(key);
                 }
+
+                this.nonLazyDictionary[key] = value;
             }
 
-            return methodBase.Invoke(this.target, parameters);
+            return null;
         }
     }
 }

--- a/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
+++ b/tests/Our.Umbraco.Ditto.Tests/Our.Umbraco.Ditto.Tests.csproj
@@ -199,6 +199,7 @@
     <Compile Include="InheritedClassWithPrefixedPropertyTests.cs" />
     <Compile Include="Mocks\MockLogger.cs" />
     <Compile Include="Issue177Tests.cs" />
+    <Compile Include="ProxyFactoryTests.cs" />
     <Compile Include="SetMethodTests.cs" />
     <Compile Include="JsonSerializationWithTypeConverterTests.cs" />
     <Compile Include="MockProcessorTests.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/ProxyFactoryTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ProxyFactoryTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Our.Umbraco.Ditto.Tests
+{
+    [TestFixture]
+    [Category("Proxy Generation")]
+    public class ProxyFactoryTests
+    {
+        [Test]
+        public void ProxyCanGetSetProperties()
+        {
+            var factory = new ProxyFactory();
+            IProxy proxy = factory.CreateProxy(typeof(TestClass), new List<string> { "id", "name" });
+            proxy.Interceptor = new LazyInterceptor(new Dictionary<string, Lazy<object>>());
+
+            // This is the method we are replicating within the property emitter.
+            var tc = new TestClass();
+
+            var idMethod =
+                MethodBase.GetMethodFromHandle(typeof(TestClass).GetMethod("set_Id", new[] { typeof(int) }).MethodHandle);
+
+            var nameMethod =
+                MethodBase.GetMethodFromHandle(typeof(TestClass).GetMethod("set_Name", new[] { typeof(string) }).MethodHandle);
+
+            var dateMethod =
+                MethodBase.GetMethodFromHandle(typeof(TestClass).GetMethod("set_CreateDate", new[] { typeof(DateTime) }).MethodHandle);
+
+            idMethod.Invoke(tc, new object[] { 1 });
+            nameMethod.Invoke(tc, new object[] { "Foo" });
+            dateMethod.Invoke(tc, new object[] { new DateTime(2017, 1, 1) });
+
+            Assert.AreEqual(1, tc.Id);
+            Assert.AreEqual("Foo", tc.Name);
+            Assert.AreEqual(new DateTime(2017, 1, 1), tc.CreateDate);
+
+            // ReSharper disable once SuspiciousTypeConversion.Global
+            var testClass = (TestClass)proxy;
+
+            testClass.Id = 1;
+            testClass.Name = "Foo";
+            testClass.CreateDate = new DateTime(2017, 1, 1);
+
+            Assert.AreEqual(1, testClass.Id);
+            Assert.AreEqual("Foo", testClass.Name);
+            Assert.AreEqual(new DateTime(2017, 1, 1), testClass.CreateDate);
+        }
+    }
+
+    public class TestClass
+    {
+        public virtual int Id { get; set; }
+
+        public virtual string Name { get; set; }
+
+        public DateTime CreateDate { get; set; }
+    }
+}


### PR DESCRIPTION
So it turns out setting properties for proxied instances was broken for value types.

We got away with it because we actually had two instances of the mapped type (one proxied and one not) on the go at one time. (obviously not efficient) and were setting the property on the hidden copy.

This PR fixes that and also changes the interceptor to only attempt to intercept the lazy properties (as removing the copy would create an infinite recursion of interception)

We also don't now attempt to create a proxy from a non-null instance as that would simply replace the instance.

