### PR TITLE
DittoMultiProcessor doesn't set UmbracoContext

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoMultiProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoMultiProcessorAttribute.cs
@@ -49,6 +49,10 @@ namespace Our.Umbraco.Ditto
                 // Get the right context type
                 var newCtx = this.ChainContext.ProcessorContexts.GetOrCreate(this.Context, processorAttr.ContextType);
 
+                // Populate UmbracoContext & ApplicationContext
+                processorAttr.UmbracoContext = this.UmbracoContext;
+                processorAttr.ApplicationContext = this.ApplicationContext;
+
                 // Process value
                 this.Value = processorAttr.ProcessValue(this.Value, newCtx, this.ChainContext);
             }


### PR DESCRIPTION
When using a Ditto multi-processor, the base `UmbracoContext` and `ApplicationContext` are null (not set).
This fix sets the values based on the current instances (from the multi-processor).