### PR TITLE
Attributed Type Resolver

### DIFF
--- a/src/Our.Umbraco.Ditto/Bootstrapper.cs
+++ b/src/Our.Umbraco.Ditto/Bootstrapper.cs
@@ -1,0 +1,29 @@
+﻿using Umbraco.Core;
+
+namespace Our.Umbraco.Ditto
+{
+    internal sealed class Bootstrapper : ApplicationEventHandler
+    {
+        protected override void ApplicationInitialized(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            // Add lookups for types with specific Ditto attributes...
+            if (PluginManager.Current != null)
+            {
+                if (AttributedTypeResolver<DittoCacheAttribute>.HasCurrent == false)
+                {
+                    AttributedTypeResolver<DittoCacheAttribute>.Current = AttributedTypeResolver<DittoCacheAttribute>.Create(PluginManager.Current);
+                }
+
+                if (AttributedTypeResolver<DittoDefaultProcessorAttribute>.HasCurrent == false)
+                {
+                    AttributedTypeResolver<DittoDefaultProcessorAttribute>.Current = AttributedTypeResolver<DittoDefaultProcessorAttribute>.Create(PluginManager.Current);
+                }
+
+                if (AttributedTypeResolver<UmbracoPropertiesAttribute>.HasCurrent == false)
+                {
+                    AttributedTypeResolver<UmbracoPropertiesAttribute>.Current = AttributedTypeResolver<UmbracoPropertiesAttribute>.Create(PluginManager.Current);
+                }
+            }
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/ObjectResolution/AttributedTypeResolver.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/ObjectResolution/AttributedTypeResolver.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+
+namespace Our.Umbraco.Ditto
+{
+    /// <summary>
+    /// A resolver class to provide a lookup for a specific Ditto attribue for a given type.
+    /// </summary>
+    /// <typeparam name="TAttribute">A specific Ditto attribute type.</typeparam>
+    internal sealed class AttributedTypeResolver<TAttribute> where TAttribute : Attribute
+    {
+        private readonly ConcurrentDictionary<Type, TAttribute> _attributedTypeLookup;
+
+        private AttributedTypeResolver()
+        {
+            _attributedTypeLookup = new ConcurrentDictionary<Type, TAttribute>();
+        }
+
+        private void Initialize(IEnumerable<Type> types)
+        {
+            if (types != null)
+            {
+                foreach (var type in types)
+                {
+                    var attribute = type.GetCustomAttribute<TAttribute>(false);
+                    if (attribute != null && _attributedTypeLookup.ContainsKey(type) == false)
+                    {
+                        _attributedTypeLookup.TryAdd(type, attribute);
+                    }
+                    else
+                    {
+                        LogHelper.Warn<AttributedTypeResolver<TAttribute>>($"Duplicate '{nameof(TAttribute)}' attribute found in type: '{type}'");
+                    }
+                }
+            }
+        }
+
+        private static AttributedTypeResolver<TAttribute> _resolver;
+
+        /// <summary>
+        /// A static instance of the attributed type resolver.
+        /// </summary>
+        public static AttributedTypeResolver<TAttribute> Current
+        {
+            get { return _resolver; }
+            set { _resolver = value; }
+        }
+
+        /// <summary>
+        /// Returns true if the resolver instance is currently available.
+        /// </summary>
+        public static bool HasCurrent
+        {
+            get { return _resolver != null; }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the attributed type resolver.
+        /// </summary>
+        /// <param name="pluginManager">An instance of Umbraco's PluginManager object.</param>
+        /// <returns>Returns a new instance of the attributed type resolver.</returns>
+        public static AttributedTypeResolver<TAttribute> Create(PluginManager pluginManager)
+        {
+            return Create(pluginManager.ResolveAttributedTypes<TAttribute>());
+        }
+
+        /// <summary>
+        /// Creates a new instance of the attributed type resolver.
+        /// </summary>
+        /// <param name="types">An enumerable of attributed types.</param>
+        /// <returns>Returns a new instance of the attributed type resolver.</returns>
+        public static AttributedTypeResolver<TAttribute> Create(IEnumerable<Type> types)
+        {
+            var resolver = new AttributedTypeResolver<TAttribute>();
+
+            resolver.Initialize(types);
+
+            return resolver;
+        }
+
+        /// <summary>
+        /// Tries to get the associated attribute for a given type.
+        /// </summary>
+        /// <param name="type">The object type.</param>
+        /// <param name="attribute">The attribute.</param>
+        /// <returns>Returns the associated attribute for the given type.</returns>
+        public bool TryGetAttribute(Type type, out TAttribute attribute)
+        {
+            return _attributedTypeLookup.TryGetValue(type, out attribute);
+        }
+
+        /// <summary>
+        /// Gets the associated attribute for a given type.
+        /// </summary>
+        /// <param name="type">The object type.</param>
+        /// <returns>Returns the associated attribute for the given type.</returns>
+        public TAttribute GetAttribute(Type type)
+        {
+            return _attributedTypeLookup.TryGetValue(type, out TAttribute attribute)
+                ? attribute
+                : null;
+        }
+    }
+}

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoProcessorRegistry.cs
@@ -127,8 +127,7 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public DittoProcessorAttribute GetDefaultProcessorFor(Type objectType)
         {
-            var attr = objectType.GetCustomAttribute<DittoDefaultProcessorAttribute>();
-            if (attr != null)
+            if (Ditto.TryGetAttribute(objectType, out DittoDefaultProcessorAttribute attr))
             {
                 return (DittoProcessorAttribute)attr.ProcessorType.GetInstance();
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
@@ -93,31 +93,26 @@ namespace Our.Umbraco.Ditto
             var altPropName = string.Empty;
 
             // Check for Umbraco properties attribute on class
-            if (this.Context.TargetType != null)
+            if (this.Context.TargetType != null && Ditto.TryGetAttribute(this.Context.TargetType, out UmbracoPropertiesAttribute classAttr))
             {
-                // TODO: [LK:2017-09-26] Is there a way to optimise or avoid this?
-                var classAttr = this.Context.TargetType.GetCustomAttribute<UmbracoPropertiesAttribute>();
-                if (classAttr != null)
+                // Apply the prefix
+                if (!string.IsNullOrWhiteSpace(classAttr.Prefix))
                 {
-                    // Apply the prefix
-                    if (!string.IsNullOrWhiteSpace(classAttr.Prefix))
-                    {
-                        altPropName = propName;
-                        propName = classAttr.Prefix + propName;
-                    }
+                    altPropName = propName;
+                    propName = classAttr.Prefix + propName;
+                }
 
-                    // Apply global recursive setting
-                    recursive |= classAttr.Recursive;
+                // Apply global recursive setting
+                recursive |= classAttr.Recursive;
 
-                    // Apply property source only if it's different from the default,
-                    // and the current value is the default. We only do it this
-                    // way because if they change it at the property level, we
-                    // want that to take precedence over the class level.
-                    if (classAttr.PropertySource != Ditto.DefaultPropertySource
-                        && PropertySource == Ditto.DefaultPropertySource)
-                    {
-                        PropertySource = classAttr.PropertySource;
-                    }
+                // Apply property source only if it's different from the default,
+                // and the current value is the default. We only do it this
+                // way because if they change it at the property level, we
+                // want that to take precedence over the class level.
+                if (classAttr.PropertySource != Ditto.DefaultPropertySource
+                    && PropertySource == Ditto.DefaultPropertySource)
+                {
+                    PropertySource = classAttr.PropertySource;
                 }
             }
 

--- a/src/Our.Umbraco.Ditto/Ditto.cs
+++ b/src/Our.Umbraco.Ditto/Ditto.cs
@@ -183,5 +183,23 @@ namespace Our.Umbraco.Ditto
         {
             DittoProcessorRegistry.Instance.DeregisterPostProcessorType<TProcessorAttributeType>();
         }
+
+        /// <summary>
+        /// Tries to get the associated attribute for a given object type.
+        /// </summary>
+        /// <typeparam name="TAttribute"></typeparam>
+        /// <param name="objectType">The object type.</param>
+        /// <param name="attribute">The attribute.</param>
+        /// <returns>Returns the associated attribute for the given type.</returns>
+        public static bool TryGetAttribute<TAttribute>(Type objectType, out TAttribute attribute) where TAttribute : Attribute
+        {
+            if (AttributedTypeResolver<TAttribute>.HasCurrent == false)
+            {
+                attribute = null;
+                return false;
+            }
+
+            return AttributedTypeResolver<TAttribute>.Current.TryGetAttribute(objectType, out attribute);
+        }
     }
 }

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -222,8 +222,7 @@ namespace Our.Umbraco.Ditto
             // Convert
             using (DittoDisposableTimer.DebugDuration<Ditto>($"As<{type.Name}>({content.DocumentTypeAlias} {content.Id})"))
             {
-                var cacheAttr = type.GetCustomAttribute<DittoCacheAttribute>(true);
-                if (cacheAttr != null)
+                if (Ditto.TryGetAttribute(type, out DittoCacheAttribute cacheAttr))
                 {
                     var ctx = new DittoCacheContext(cacheAttr, content, type, culture);
                     return cacheAttr.GetCacheItem(ctx, () => ConvertContent(content, type, contextAccessor, culture, instance, onConverting, onConverted, chainContext));

--- a/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
+++ b/src/Our.Umbraco.Ditto/Our.Umbraco.Ditto.csproj
@@ -75,6 +75,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Bootstrapper.cs" />
     <Compile Include="Common\CachedInvocations.cs" />
     <Compile Include="Common\FastPropertyAccessor.cs" />
     <Compile Include="Common\DittoContextAccessor.cs" />
@@ -84,6 +85,7 @@
     <Compile Include="ComponentModel\Attributes\DittoCacheableAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoCacheAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoProcessorMetaDataAttribute.cs" />
+    <Compile Include="ComponentModel\ObjectResolution\AttributedTypeResolver.cs" />
     <Compile Include="ComponentModel\Processors\AppSettingAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoConversionHandlerAttribute.cs" />
     <Compile Include="ComponentModel\Attributes\DittoOnConvertingAttribute.cs" />

--- a/tests/Our.Umbraco.Ditto.Tests/GlobalSetupFixture.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/GlobalSetupFixture.cs
@@ -10,6 +10,38 @@ namespace Our.Umbraco.Ditto.Tests
         public void Setup()
         {
             Ditto.RegisterContextAccessor<MockDittoContextAccessor>();
+
+            // In order for the unit-test to work, we need to populate the attributed
+            //-types resolver with the object types that have resolvable attributes.
+
+            // Manually set the `DittoCache` attributed types
+            if (AttributedTypeResolver<DittoCacheAttribute>.HasCurrent == false)
+            {
+                AttributedTypeResolver<DittoCacheAttribute>.Current = AttributedTypeResolver<DittoCacheAttribute>.Create(new[]
+                {
+                    typeof(CacheTests.MyValueResolverModel2)
+                });
+            }
+
+            // Manually set the `DittoDefaultProcessor` attributed types
+            if (AttributedTypeResolver<DittoDefaultProcessorAttribute>.HasCurrent == false)
+            {
+                AttributedTypeResolver<DittoDefaultProcessorAttribute>.Current = AttributedTypeResolver<DittoDefaultProcessorAttribute>.Create(new[]
+                {
+                    typeof(DefaultProcessorTests.MyCustomModel)
+                });
+            }
+
+            // Manually set the `UmbracoProperties` attributed types
+            if (AttributedTypeResolver<UmbracoPropertiesAttribute>.HasCurrent == false)
+            {
+                AttributedTypeResolver<UmbracoPropertiesAttribute>.Current = AttributedTypeResolver<UmbracoPropertiesAttribute>.Create(new[]
+                {
+                    typeof(PropertySourceMappingTests.BasicModelProperty2),
+                    typeof(PrefixedPropertyTests.MyModel),
+                    typeof(InheritedClassWithPrefixedPropertyTests.InheritedModel)
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a resolver class to provide a lookup for specific Ditto attributes for a given type.
The thinking behind this is that we have a few places where we check for a custom attribute, e.g. the `UmbracoProperties` attribute inside the `UmbracoProperty` processor.
Given that this is called for each object's property, it has the potential of being queried a lot of times.

Of course this adds time to app startup, but then it's a once-off operation.

Would like to know your thoughts on this approach.