### PR TITLE
Deprecate PropertyDescriptor in Contexts

### DIFF
--- a/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoProcessorAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Attributes/DittoProcessorAttribute.cs
@@ -196,7 +196,7 @@ namespace Our.Umbraco.Ditto
             this.Context = context;
             this.ChainContext = chainContext;
 
-            var ctx = new DittoCacheContext(this, context.Content, context.TargetType, context.PropertyDescriptor, context.Culture);
+            var ctx = new DittoCacheContext(this, context.Content, context.TargetType, context.PropertyInfo, context.Culture);
             return this.GetCacheItem(ctx, this.ProcessValue);
         }
     }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Caching/DittoCacheContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Caching/DittoCacheContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Reflection;
 using Umbraco.Core.Models;
 
 namespace Our.Umbraco.Ditto
@@ -30,21 +31,21 @@ namespace Our.Umbraco.Ditto
         /// </summary>
         /// <param name="attribute">The attribute.</param>
         /// <param name="content">The content.</param>
-        /// <param name="targetType">Type of the target.</param>
-        /// <param name="propertyDescriptor">The property descriptor.</param>
+        /// <param name="targetType">Type of the target.</param> 
+        /// <param name="propertyInfo">The property info.</param>
         /// <param name="culture">The culture.</param>
         internal DittoCacheContext(
             DittoCacheableAttribute attribute,
             IPublishedContent content,
             Type targetType,
-            PropertyDescriptor propertyDescriptor,
+            PropertyInfo propertyInfo,
             CultureInfo culture)
         {
             this.Attribute = attribute;
             this.Content = content;
             this.TargetType = targetType;
             this.Culture = culture;
-            this.PropertyDescriptor = propertyDescriptor;
+            this.PropertyInfo = propertyInfo;
         }
 
         /// <summary>
@@ -69,7 +70,24 @@ namespace Our.Umbraco.Ditto
         /// <value>
         /// The property descriptor.
         /// </value>
-        public PropertyDescriptor PropertyDescriptor { get; internal set; }
+        [Obsolete("PropertyDescriptor has been deprecated, please use PropertyInfo instead. This property will be removed in a future Ditto version.", false)]
+        public PropertyDescriptor PropertyDescriptor
+        {
+            get
+            {
+                return this.TargetType != null && this.PropertyInfo != null
+                    ? TypeDescriptor.GetProperties(this.TargetType)[this.PropertyInfo.Name]
+                    : null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the property info.
+        /// </summary>
+        /// <value>
+        /// The property info.
+        /// </value>
+        public PropertyInfo PropertyInfo { get; set; }
 
         /// <summary>
         /// Gets the culture.

--- a/src/Our.Umbraco.Ditto/ComponentModel/Caching/DittoDefaultCacheKeyBuilder.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Caching/DittoDefaultCacheKeyBuilder.cs
@@ -26,9 +26,9 @@ namespace Our.Umbraco.Ditto
                 cacheKey.Add(context.Content.Version);
             }
 
-            if (context.PropertyDescriptor != null && (context.Attribute.CacheBy & DittoCacheBy.PropertyName) == DittoCacheBy.PropertyName)
+            if (context.PropertyInfo != null && (context.Attribute.CacheBy & DittoCacheBy.PropertyName) == DittoCacheBy.PropertyName)
             {
-                cacheKey.Add(context.PropertyDescriptor.Name);
+                cacheKey.Add(context.PropertyInfo.Name);
             }
 
             if ((context.Attribute.CacheBy & DittoCacheBy.TargetType) == DittoCacheBy.TargetType)

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/AppSettingAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/AppSettingAttribute.cs
@@ -31,7 +31,7 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public override object ProcessValue()
         {
-            var appSettingKey = this.AppSettingKey ?? (this.Context.PropertyDescriptor != null ? this.Context.PropertyDescriptor.Name : string.Empty);
+            var appSettingKey = this.AppSettingKey ?? (this.Context.PropertyInfo != null ? this.Context.PropertyInfo.Name : string.Empty);
 
             if (string.IsNullOrWhiteSpace(appSettingKey))
             {

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoProcessorContext.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/Contexts/DittoProcessorContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Reflection;
 using Umbraco.Core.Models;
 
 namespace Our.Umbraco.Ditto
@@ -32,7 +33,24 @@ namespace Our.Umbraco.Ditto
         /// <value>
         /// The property descriptor.
         /// </value>
-        public PropertyDescriptor PropertyDescriptor { get; internal set; }
+        [Obsolete("PropertyDescriptor has been deprecated, please use PropertyInfo instead. This property will be removed in a future Ditto version.", false)]
+        public PropertyDescriptor PropertyDescriptor
+        {
+            get
+            {
+                return this.TargetType != null && this.PropertyInfo != null
+                    ? TypeDescriptor.GetProperties(this.TargetType)[this.PropertyInfo.Name]
+                    : null;
+            }
+        }
+
+        /// <summary>
+        /// Gets the property info.
+        /// </summary>
+        /// <value>
+        /// The property info.
+        /// </value>
+        public PropertyInfo PropertyInfo { get; set; }
 
         /// <summary>
         /// Gets the culture.
@@ -51,7 +69,7 @@ namespace Our.Umbraco.Ditto
         {
             Content = baseProcessorContext.Content;
             TargetType = baseProcessorContext.TargetType;
-            PropertyDescriptor = baseProcessorContext.PropertyDescriptor;
+            PropertyInfo = baseProcessorContext.PropertyInfo;
             Culture = baseProcessorContext.Culture;
 
             return this;

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/CurrentContentAsAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/CurrentContentAsAttribute.cs
@@ -19,9 +19,9 @@ namespace Our.Umbraco.Ditto
         {
             // NOTE: [LK] In order to prevent an infinite loop / stack-overflow, we check if the
             // property's type matches the containing model's type, then we throw an exception.
-            if (this.Context.PropertyDescriptor.PropertyType == this.Context.PropertyDescriptor.ComponentType)
+            if (this.Context.PropertyInfo.PropertyType == this.Context.TargetType)
             {
-                throw new InvalidOperationException($"Unable to process property type '{this.Context.PropertyDescriptor.PropertyType.Name}', it is the same as the containing model type.");
+                throw new InvalidOperationException($"Unable to process property type '{this.Context.TargetType.Name}', it is the same as the containing model type.");
             }
 
             return this.Context.Content;

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoFactoryAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/DittoFactoryAttribute.cs
@@ -48,7 +48,7 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public override object ProcessValue()
         {
-            var propType = this.Context.PropertyDescriptor.PropertyType;
+            var propType = this.Context.PropertyInfo.PropertyType;
             var propTypeIsEnumerable = propType.IsEnumerableType();
             var baseType = propTypeIsEnumerable ? propType.GetEnumerableType() : propType;
 

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/EnumAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/EnumAttribute.cs
@@ -19,12 +19,12 @@ namespace Our.Umbraco.Ditto
         public override object ProcessValue()
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (this.Context == null || this.Context.PropertyDescriptor == null)
+            if (this.Context == null || this.Context.PropertyInfo == null)
             {
                 return null;
             }
 
-            var propertyType = this.Context.PropertyDescriptor.PropertyType;
+            var propertyType = this.Context.PropertyInfo.PropertyType;
 
             if (this.Value.IsNullOrEmptyString())
             {

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/EnumerableConverterAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/EnumerableConverterAttribute.cs
@@ -35,7 +35,7 @@ namespace Our.Umbraco.Ditto
         public override object ProcessValue()
         {
             object result = this.Value;
-            var propertyType = this.Context.PropertyDescriptor.PropertyType;
+            var propertyType = this.Context.PropertyInfo.PropertyType;
             var propertyIsEnumerableType = Direction == EnumerableConvertionDirection.Automatic
                 ? propertyType.IsEnumerableType()
                     && (propertyType == typeof(string)) == false

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/HtmlStringAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/HtmlStringAttribute.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.Ditto
         /// </returns>
         public override object ProcessValue()
         {
-            if (typeof(IHtmlString).IsAssignableFrom(this.Context.PropertyDescriptor.PropertyType))
+            if (typeof(IHtmlString).IsAssignableFrom(this.Context.PropertyInfo.PropertyType))
             {
                 if (this.Value.IsNullOrEmptyString())
                 {

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/RecursiveDittoAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/RecursiveDittoAttribute.cs
@@ -25,25 +25,25 @@ namespace Our.Umbraco.Ditto
             var result = this.Value;
 
             // If we aren't already the right type, try recursing if the type is IPublishedContent
-            if (this.Value != null && !this.Context.PropertyDescriptor.PropertyType.IsInstanceOfType(this.Value))
+            if (this.Value != null && !this.Context.PropertyInfo.PropertyType.IsInstanceOfType(this.Value))
             {
-                if (this.Value is IPublishedContent && this.Context.PropertyDescriptor.PropertyType.IsClass)
+                if (this.Value is IPublishedContent && this.Context.PropertyInfo.PropertyType.IsClass)
                 {
                     // If the property value is an IPublishedContent, then we can use Ditto to map to the target type.
                     result = ((IPublishedContent)this.Value).As(
-                        this.Context.PropertyDescriptor.PropertyType,
+                        this.Context.PropertyInfo.PropertyType,
                         this.Context.Culture,
                         null,
                         chainContext: ChainContext);
                 }
                 else if (this.Value != null && this.Value.GetType().IsEnumerableOfType(typeof(IPublishedContent))
-                    && this.Context.PropertyDescriptor.PropertyType.IsEnumerable()
-                    && this.Context.PropertyDescriptor.PropertyType.GetEnumerableType() != null
-                    && this.Context.PropertyDescriptor.PropertyType.GetEnumerableType().IsClass)
+                    && this.Context.PropertyInfo.PropertyType.IsEnumerable()
+                    && this.Context.PropertyInfo.PropertyType.GetEnumerableType() != null
+                    && this.Context.PropertyInfo.PropertyType.GetEnumerableType().IsClass)
                 {
                     // If the property value is IEnumerable<IPublishedContent>, then we can use Ditto to map to the target type.
                     result = ((IEnumerable<IPublishedContent>)this.Value).As(
-                        this.Context.PropertyDescriptor.PropertyType.GetEnumerableType(),
+                        this.Context.PropertyInfo.PropertyType.GetEnumerableType(),
                         this.Context.Culture,
                         chainContext: ChainContext);
                 }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/TryConvertToAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/TryConvertToAttribute.cs
@@ -17,12 +17,12 @@ namespace Our.Umbraco.Ditto
         {
             var result = this.Value;
 
-            if (this.Value != null && !this.Context.PropertyDescriptor.PropertyType.IsInstanceOfType(this.Value))
+            if (this.Value != null && !this.Context.PropertyInfo.PropertyType.IsInstanceOfType(this.Value))
             {
                 // TODO: Maybe support enumerables?
-                using (DittoDisposableTimer.DebugDuration<TryConvertToAttribute>($"TryConvertTo '{this.Context.PropertyDescriptor.Name}' ({this.Context.Content.Id})"))
+                using (DittoDisposableTimer.DebugDuration<TryConvertToAttribute>($"TryConvertTo '{this.Context.PropertyInfo.Name}' ({this.Context.Content.Id})"))
                 {
-                    var convert = this.Value.TryConvertTo(this.Context.PropertyDescriptor.PropertyType);
+                    var convert = this.Value.TryConvertTo(this.Context.PropertyInfo.PropertyType);
                     if (convert.Success)
                     {
                         result = convert.Result;

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoDictionaryAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoDictionaryAttribute.cs
@@ -39,7 +39,7 @@ namespace Our.Umbraco.Ditto
         public override object ProcessValue()
         {
             var dictionaryKey = this.DictionaryKey
-                ?? (this.Context.PropertyDescriptor != null ? this.Context.PropertyDescriptor.Name : string.Empty);
+                ?? (this.Context.PropertyInfo != null ? this.Context.PropertyInfo.Name : string.Empty);
 
             if (string.IsNullOrWhiteSpace(dictionaryKey))
             {

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPickerAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPickerAttribute.cs
@@ -22,7 +22,7 @@ namespace Our.Umbraco.Ditto
         public override object ProcessValue()
         {
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (this.Context == null || this.Context.PropertyDescriptor == null || this.Value.IsNullOrEmptyString())
+            if (this.Context == null || this.Context.PropertyInfo == null || this.Value.IsNullOrEmptyString())
             {
                 return Enumerable.Empty<IPublishedContent>();
             }

--- a/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
+++ b/src/Our.Umbraco.Ditto/ComponentModel/Processors/UmbracoPropertyAttribute.cs
@@ -89,7 +89,7 @@ namespace Our.Umbraco.Ditto
             var defaultValue = this.DefaultValue;
 
             var recursive = this.Recursive;
-            var propName = this.Context.PropertyDescriptor != null ? this.Context.PropertyDescriptor.Name : string.Empty;
+            var propName = this.Context.PropertyInfo != null ? this.Context.PropertyInfo.Name : string.Empty;
             var altPropName = string.Empty;
 
             // Check for Umbraco properties attribute on class

--- a/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
+++ b/src/Our.Umbraco.Ditto/Extensions/PublishedContentExtensions.cs
@@ -328,15 +328,12 @@ namespace Our.Umbraco.Ditto
         {
             using (DittoDisposableTimer.DebugDuration(typeof(Ditto), $"Processing '{propertyInfo.Name}' ({content.Id})"))
             {
-                // Get the target property description
-                var propertyDescriptor = TypeDescriptor.GetProperties(instance)[propertyInfo.Name];
-
                 // Create a base processor context for this current chain level
                 var baseProcessorContext = new DittoProcessorContext
                 {
                     Content = content,
                     TargetType = targetType,
-                    PropertyDescriptor = propertyDescriptor,
+                    PropertyInfo = propertyInfo,
                     Culture = culture
                 };
 
@@ -344,7 +341,7 @@ namespace Our.Umbraco.Ditto
                 var cacheAttr = propertyInfo.GetCustomAttribute<DittoCacheAttribute>(true);
                 if (cacheAttr != null)
                 {
-                    var ctx = new DittoCacheContext(cacheAttr, content, targetType, propertyDescriptor, culture);
+                    var ctx = new DittoCacheContext(cacheAttr, content, targetType, propertyInfo, culture);
                     return cacheAttr.GetCacheItem(ctx, () => DoGetProcessedValue(content, propertyInfo, contextAccessor, baseProcessorContext, chainContext));
                 }
                 else

--- a/tests/Our.Umbraco.Ditto.Tests/EnumerableConverterTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/EnumerableConverterTests.cs
@@ -62,7 +62,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             var context = new DittoProcessorContext
             {
-                PropertyDescriptor = TypeDescriptor.GetProperties(new WrappedModel())["MyProperty1"]
+                PropertyInfo = typeof(WrappedModel).GetProperty("MyProperty1")
             };
 
             var processor = new EnumerableConverterAttribute();
@@ -76,7 +76,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             var context = new DittoProcessorContext
             {
-                PropertyDescriptor = TypeDescriptor.GetProperties(new WrappedModel())["MyProperty2"]
+                PropertyInfo = typeof(WrappedModel).GetProperty("MyProperty2")
             };
 
             var processor = new EnumerableConverterAttribute();
@@ -91,7 +91,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             var context = new DittoProcessorContext
             {
-                PropertyDescriptor = TypeDescriptor.GetProperties(new WrappedModel())["MyProperty3"]
+                PropertyInfo = typeof(WrappedModel).GetProperty("MyProperty3")
             };
 
             var processor = new EnumerableConverterAttribute();
@@ -105,7 +105,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             var context = new DittoProcessorContext
             {
-                PropertyDescriptor = TypeDescriptor.GetProperties(new WrappedModel())["MyProperty4"]
+                PropertyInfo = typeof(WrappedModel).GetProperty("MyProperty4")
             };
 
             var processor = new EnumerableConverterAttribute();

--- a/tests/Our.Umbraco.Ditto.Tests/ExtremeChainedContextTests.cs
+++ b/tests/Our.Umbraco.Ditto.Tests/ExtremeChainedContextTests.cs
@@ -39,7 +39,7 @@ namespace Our.Umbraco.Ditto.Tests
         {
             public override object ProcessValue()
             {
-                Assert.That(this.Context.PropertyDescriptor.Name, Is.EqualTo("MyProperty"));
+                Assert.That(this.Context.PropertyInfo.Name, Is.EqualTo("MyProperty"));
 
                 var items = Value as IEnumerable;
                 foreach (var item in items)
@@ -47,7 +47,7 @@ namespace Our.Umbraco.Ditto.Tests
                     // do nothing, we just need the for-loop so that the collection is evaluated
                 }
 
-                Assert.That(this.Context.PropertyDescriptor.Name, Is.EqualTo("MyProperty"));
+                Assert.That(this.Context.PropertyInfo.Name, Is.EqualTo("MyProperty"));
 
                 return Value;
             }


### PR DESCRIPTION
The reason we're using the `PropertyDescriptor` is due to Ditto original use of TypeConverters.
When we rolled up the TypeConverters and ValueResolvers, we'd kept `PropertyDescriptor` available.

However the use of reflection in Ditto's internals, there is an additional call made to exclusively get the `PropertyDescriptor`. If we switch this to use the `PropertyInfo`, (which we already have a local reference to), then this can be used to access any metadata about the property itself.

So not to make this a rough breaking-change, I'd left the `PropertyDescriptor` property available on the Contexts, so not to completely ruin the developer experience.  I added an obsolete/warning message saying that it would be removed in a future release.

Does anyone foresee any downsides with this approach?